### PR TITLE
Refine set_power_limits and add clear_power_limits service

### DIFF
--- a/custom_components/e3dc_rscp/const.py
+++ b/custom_components/e3dc_rscp/const.py
@@ -7,6 +7,7 @@ CONF_VERSION = 1
 DOMAIN = "e3dc_rscp"
 ERROR_AUTH_INVALID = "invalid_auth"
 ERROR_CANNOT_CONNECT = "cannot_connect"
+SERVICE_CLEAR_POWER_LIMITS = "clear_power_limits"
 SERVICE_SET_POWER_LIMITS = "set_power_limits"
 
 PLATFORMS: list[Platform] = [

--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -340,10 +340,10 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
 
         if max_charge is not None and max_charge > self.e3dc.maxBatChargePower:
-            _LOGGER.debug("Limiting max_charge to %s", self.e3dc.maxBatChargePower)
+            _LOGGER.warning("Limiting max_charge to %s", self.e3dc.maxBatChargePower)
             max_charge = self.e3dc.maxBatChargePower
         if max_discharge is not None and max_discharge > self.e3dc.maxBatDischargePower:
-            _LOGGER.debug(
+            _LOGGER.warning(
                 "Limiting max_discharge to %s", self.e3dc.maxBatDischargePower
             )
             max_discharge = self.e3dc.maxBatDischargePower
@@ -361,16 +361,16 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.e3dc.set_power_limits, True, max_charge, max_discharge, None, True
             )
         except Exception as ex:
-            _LOGGER.exception("Failed to update power limits")
-            raise HomeAssistantError("Failed to update power limits") from ex
+            _LOGGER.exception("Failed to set power limits")
+            raise HomeAssistantError("Failed to set power limits") from ex
 
         if result == -1:
-            raise HomeAssistantError("Failed to update power limits")
+            raise HomeAssistantError("Failed to set power limits")
 
         if result == 1:
-            _LOGGER.warning("The given power limits are not optimal, continuing Anyway")
+            _LOGGER.warning("The given power limits are not optimal, continuing anyway")
         else:
-            _LOGGER.warning("Successfully set the power limits")
+            _LOGGER.debug("Successfully set the power limits")
 
 
 def create_e3dcinstance(username: str, password: str, host: str, rscpkey: str) -> E3DC:

--- a/custom_components/e3dc_rscp/services.py
+++ b/custom_components/e3dc_rscp/services.py
@@ -5,11 +5,17 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall
-
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import (
+    DeviceEntry,
+    DeviceRegistry,
+    async_get,
+)
 from .const import DOMAIN, SERVICE_SET_POWER_LIMITS
 from .coordinator import E3DCCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+_device_map: dict[str, E3DCCoordinator] = {}
 
 ATTR_DEVICEID = "device_id"
 ATTR_MAX_CHARGE = "max_charge"
@@ -39,15 +45,39 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     )
 
 
+def _resolve_device_id(hass: HomeAssistant, devid: str) -> E3DCCoordinator:
+    """Resolve a device ID to its coordinator with caching."""
+    if devid in _device_map:
+        return _device_map[devid]
+    dev_reg: DeviceRegistry = async_get(hass)
+    dev: DeviceEntry = dev_reg.async_get(devid)
+    if dev is None:
+        raise HomeAssistantError(
+            f"{SERVICE_SET_POWER_LIMITS}: Unkown device ID {devid}."
+        )
+
+    identifier: tuple(str, str) = next(iter(dev.identifiers))
+    if identifier[0] != DOMAIN:
+        raise HomeAssistantError(
+            f"{SERVICE_SET_POWER_LIMITS}: Device {devid} is no E3DC."
+        )
+
+    uid: str = identifier[1]
+    coordinator: E3DCCoordinator = hass.data[DOMAIN][uid]
+    _device_map[devid] = coordinator
+    return uid
+
+
 async def _async_set_power_limits(hass: HomeAssistant, call: ServiceCall) -> None:
     """Extract service information and relay to coordinator."""
-    uid = call.data.get(ATTR_DEVICEID)
-    coordinator: E3DCCoordinator = hass.data[DOMAIN][uid]
+    coordinator: E3DCCoordinator = _resolve_device_id(
+        hass, call.data.get(ATTR_DEVICEID)
+    )
     max_charge: int | None = call.data.get(ATTR_MAX_CHARGE)
     max_discharge: int | None = call.data.get(ATTR_MAX_DISCHARGE)
     if max_charge is None and max_discharge is None:
-        raise ValueError(
-            f"SERVICE_SET_POWER_LIMITS: Need to set at least one of {ATTR_MAX_CHARGE} or {ATTR_MAX_DISCHARGE}"
+        raise HomeAssistantError(
+            f"{SERVICE_SET_POWER_LIMITS}: Need to set at least one of {ATTR_MAX_CHARGE} or {ATTR_MAX_DISCHARGE}"
         )
     await coordinator.async_set_power_limits(
         max_charge=max_charge, max_discharge=max_discharge

--- a/custom_components/e3dc_rscp/services.py
+++ b/custom_components/e3dc_rscp/services.py
@@ -27,7 +27,7 @@ SCHEMA_CLEAR_POWER_LIMITS = vol.Schema(
     }
 )
 
-SCHEMA_SET_POWER_KUNUTS = vol.Schema(
+SCHEMA_SET_POWER_LIMITS = vol.Schema(
     {
         vol.Required(ATTR_DEVICEID): str,
         vol.Optional(ATTR_MAX_CHARGE): vol.All(int, vol.Range(min=0)),
@@ -47,7 +47,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         service=SERVICE_SET_POWER_LIMITS,
         service_func=async_call_set_power_limits,
-        schema=SCHEMA_SET_POWER_KUNUTS,
+        schema=SCHEMA_SET_POWER_LIMITS,
     )
 
     async def async_call_clear_power_limits(call: ServiceCall) -> None:

--- a/custom_components/e3dc_rscp/services.yaml
+++ b/custom_components/e3dc_rscp/services.yaml
@@ -8,7 +8,9 @@ set_power_limits:
       required: true
       example: "S10-412345678"
       selector:
-        text:
+        device:
+          filter:
+            integration: e3dc_rscp
     max_charge:
       name: Maximum Charge (W)
       description: Maximum allowed battery charge in Watts

--- a/custom_components/e3dc_rscp/services.yaml
+++ b/custom_components/e3dc_rscp/services.yaml
@@ -1,3 +1,17 @@
+clear_power_limits:
+  name: Clear power limits
+  description: Clears any active power limit of the E3DC unit
+  fields:
+    device_id:
+      name: E3DC Device ID
+      description: E3DC Device ID
+      required: true
+      example: "S10-412345678"
+      selector:
+        device:
+          filter:
+            integration: e3dc_rscp
+
 set_power_limits:
   name: Set power limits
   description: Sets the maximum charge/discharge limits of the E3DC unit


### PR DESCRIPTION
Refine set_power_limits service for easier use

- Switch to Device ID Selection, so that you don't have to look
  for the UID of the device manually. Do some caching to avoid
  having to loop through the device registry every time.
- Add an appropriate selector to services.yaml to get an
  appropriate device list.
- Move exceptions to the correct type so that they are
  displayed in the UI.

Add clear_power_limits service 

- Allows you to clear any active power limit
- Fix device ID to coordinator cache exception on first call

Generally fix a few typos and optimize logging in power limiting code

fixes #18 