### PR TITLE
Raise minimum HA version to 2023.08

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "filename": "hacs-e3dc_rscp.zip",
     "hide_default_branch": true,
-    "homeassistant": "2023.7.0",
+    "homeassistant": "2023.8.0",
     "name": "E3DC Remote Storage Control Protocol (Git)",
     "render_readme": true,
     "zip_release": true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.7.0
-homeassistant>=2023.7.0,<2023.8.0
+homeassistant>=2023.8.0
 pip>=21.0,<23.3
 ruff==0.0.287
 pye3dc==0.7.6


### PR DESCRIPTION
Note, dev installs should always use the latest available version. This in preparation of service translations.