### PR TITLE
Emergency workaround manual charging API

### DIFF
--- a/custom_components/e3dc_rscp/manifest.json
+++ b/custom_components/e3dc_rscp/manifest.json
@@ -15,6 +15,6 @@
     "pye3dc==0.9.0"
   ],
   "ssdp": [],
-  "version": "3.6.0",
+  "version": "3.6.1-beta.1",
   "zeroconf": []
 }


### PR DESCRIPTION
Apparently, E3DC changed the manual charging API with firmware release P10_2023_06. Since then pye3dc reports an unknown tag, which then throws an exception. For now, we'll just catch it and provide dummy values for the manual charging sensors.