### PR TITLE
Wallboxes-as-devices

### DIFF
--- a/custom_components/e3dc_rscp/__init__.py
+++ b/custom_components/e3dc_rscp/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = coordinator
-    await coordinator.async_identify_wallboxes()
+    await coordinator.async_identify_wallboxes(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await async_setup_services(hass)
 

--- a/custom_components/e3dc_rscp/binary_sensor.py
+++ b/custom_components/e3dc_rscp/binary_sensor.py
@@ -79,7 +79,7 @@ async def async_setup_entry(
             off_icon="mdi:weather-sunny-off",
             device_class=None,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_sun_mode_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_sun_mode_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_plug_lock_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-plug-lock",
@@ -90,7 +90,7 @@ async def async_setup_entry(
             device_class=BinarySensorDeviceClass.LOCK,
             entity_registry_enabled_default=False,  # Disabled per default as only Wallbox easy connect provides this state
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_lock_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_lock_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_plug_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-plug",
@@ -100,7 +100,7 @@ async def async_setup_entry(
             off_icon="mdi:power-plug-off",
             device_class=BinarySensorDeviceClass.PLUG,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_schuko_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-schuko",
@@ -111,7 +111,7 @@ async def async_setup_entry(
             device_class=BinarySensorDeviceClass.POWER,
             entity_registry_enabled_default=False,   # Disabled per default as only Wallbox multi connect I provides this feature
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_schuko_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_schuko_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_charging_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-charging",
@@ -121,7 +121,7 @@ async def async_setup_entry(
             off_icon="mdi:car-electric-outline",
             device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_charging_canceled_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-charging-canceled",
@@ -131,7 +131,7 @@ async def async_setup_entry(
             off_icon="mdi:check-circle-outline",
             device_class=None,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_canceled_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_canceled_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_battery_to_car_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-battery-to-car",
@@ -142,7 +142,7 @@ async def async_setup_entry(
             device_class=None,
             entity_registry_enabled_default=False,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_battery_to_car_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_battery_to_car_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_key_state_description = E3DCBinarySensorEntityDescription(
             key=wallbox["key"] + "-key-state",
@@ -153,7 +153,7 @@ async def async_setup_entry(
             device_class=BinarySensorDeviceClass.LOCK,
             entity_registry_enabled_default=False,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_key_state_description, entry.unique_id))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_key_state_description, entry.unique_id, wallbox["deviceInfo"]))
 
     async_add_entities(entities)
 
@@ -168,6 +168,7 @@ class E3DCBinarySensor(CoordinatorEntity, BinarySensorEntity):
         coordinator: E3DCCoordinator,
         description: E3DCBinarySensorEntityDescription,
         uid: str,
+        device_info: DeviceInfo | None = None
     ) -> None:
         """Initialize the Sensor."""
         super().__init__(coordinator)
@@ -178,6 +179,10 @@ class E3DCBinarySensor(CoordinatorEntity, BinarySensorEntity):
             self.entity_description.on_icon is not None
             and self.entity_description.off_icon is not None
         )
+        if device_info is not None:
+            self._deviceInfo = device_info
+        else:
+            self._deviceInfo = self.coordinator.device_info()
 
     @property
     def is_on(self) -> bool | None:
@@ -196,4 +201,4 @@ class E3DCBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
-        return self.coordinator.device_info()
+        return self._deviceInfo

--- a/custom_components/e3dc_rscp/binary_sensor.py
+++ b/custom_components/e3dc_rscp/binary_sensor.py
@@ -70,90 +70,85 @@ async def async_setup_entry(
     ]
 
     for wallbox in coordinator.wallboxes:
+        # Get the UID & Key for the given wallbox
+        unique_id = list(wallbox["deviceInfo"]["identifiers"])[0][1]
+        wallbox_key = wallbox["key"]
 
         wallbox_sun_mode_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-sun-mode",
+            key=f"{wallbox_key}-sun-mode",
             translation_key="wallbox-sun-mode",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:weather-sunny",
             off_icon="mdi:weather-sunny-off",
             device_class=None,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_sun_mode_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_sun_mode_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_plug_lock_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-plug-lock",
+            key=f"{wallbox_key}-plug-lock",
             translation_key="wallbox-plug-lock",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:lock-open",
             off_icon="mdi:lock",
             device_class=BinarySensorDeviceClass.LOCK,
             entity_registry_enabled_default=False,  # Disabled per default as only Wallbox easy connect provides this state
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_lock_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_lock_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_plug_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-plug",
+            key=f"{wallbox_key}-plug",
             translation_key="wallbox-plug",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:power-plug",
             off_icon="mdi:power-plug-off",
             device_class=BinarySensorDeviceClass.PLUG,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_plug_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_schuko_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-schuko",
+            key=f"{wallbox_key}-schuko",
             translation_key="wallbox-schuko",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:power-plug-outline",
             off_icon="mdi:power-plug-off-outline",
             device_class=BinarySensorDeviceClass.POWER,
             entity_registry_enabled_default=False,   # Disabled per default as only Wallbox multi connect I provides this feature
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_schuko_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_schuko_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_charging_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-charging",
+            key=f"{wallbox_key}-charging",
             translation_key="wallbox-charging",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:car-electric",
             off_icon="mdi:car-electric-outline",
             device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_charging_canceled_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-charging-canceled",
+            key=f"{wallbox_key}-charging-canceled",
             translation_key="wallbox-charging-canceled",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:cancel",
             off_icon="mdi:check-circle-outline",
             device_class=None,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_canceled_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_charging_canceled_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_battery_to_car_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-battery-to-car",
+            key=f"{wallbox_key}-battery-to-car",
             translation_key="wallbox-battery-to-car",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:battery-charging",
             off_icon="mdi:battery-off",
             device_class=None,
             entity_registry_enabled_default=False,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_battery_to_car_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_battery_to_car_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_key_state_description = E3DCBinarySensorEntityDescription(
-            key=wallbox["key"] + "-key-state",
+            key=f"{wallbox_key}-key-state",
             translation_key="wallbox-key-state",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             on_icon="mdi:key-variant",
             off_icon="mdi:key-remove",
             device_class=BinarySensorDeviceClass.LOCK,
             entity_registry_enabled_default=False,
         )
-        entities.append(E3DCBinarySensor(coordinator, wallbox_key_state_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCBinarySensor(coordinator, wallbox_key_state_description, unique_id, wallbox["deviceInfo"]))
 
     async_add_entities(entities)
 

--- a/custom_components/e3dc_rscp/button.py
+++ b/custom_components/e3dc_rscp/button.py
@@ -47,24 +47,25 @@ async def async_setup_entry(
     ]
 
     for wallbox in coordinator.wallboxes:
+        # Get the UID & Key for the given wallbox
+        unique_id = list(wallbox["deviceInfo"]["identifiers"])[0][1]
+        wallbox_key = wallbox["key"]
 
         wallbox_toggle_wallbox_phases_description = E3DCButtonEntityDescription(
-            key=wallbox["key"] + "-toggle-wallbox-phases",
+            key=f"{wallbox_key}-toggle-wallbox-phases",
             translation_key="wallbox-toggle-wallbox-phases",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:sine-wave",
-            async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_phases(),
+            async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_phases(wallbox["index"]),
         )
-        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_phases_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_phases_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_toggle_wallbox_charging_description = E3DCButtonEntityDescription(
-            key=wallbox["key"] + "-toggle-wallbox-charging",
+            key=f"{wallbox_key}-toggle-wallbox-charging",
             translation_key="wallbox-toggle-wallbox-charging",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:car-electric",
-            async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_charging(),
+            async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_charging(wallbox["index"]),
         )
-        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_charging_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_charging_description, unique_id, wallbox["deviceInfo"]))
 
 
     async_add_entities(entities)

--- a/custom_components/e3dc_rscp/button.py
+++ b/custom_components/e3dc_rscp/button.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
             icon="mdi:sine-wave",
             async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_phases(),
         )
-        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_phases_description, entry.unique_id))
+        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_phases_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_toggle_wallbox_charging_description = E3DCButtonEntityDescription(
             key=wallbox["key"] + "-toggle-wallbox-charging",
@@ -64,7 +64,7 @@ async def async_setup_entry(
             icon="mdi:car-electric",
             async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_charging(),
         )
-        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_charging_description, entry.unique_id))
+        entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_charging_description, entry.unique_id, wallbox["deviceInfo"]))
 
 
     async_add_entities(entities)
@@ -80,6 +80,7 @@ class E3DCButton(CoordinatorEntity, ButtonEntity):
         coordinator: E3DCCoordinator,
         description: E3DCButtonEntityDescription,
         uid: str,
+        device_info: DeviceInfo | None = None
     ) -> None:
         """Initialize the Button."""
         super().__init__(coordinator)
@@ -87,6 +88,10 @@ class E3DCButton(CoordinatorEntity, ButtonEntity):
         self.entity_description: E3DCButtonEntityDescription = description
         self._attr_unique_id = f"{uid}_{description.key}"
         self._has_custom_icons: bool = self.entity_description.icon is not None
+        if device_info is not None:
+            self._deviceInfo = device_info
+        else:
+            self._deviceInfo = self.coordinator.device_info()
 
     @property
     def icon(self) -> str | None:
@@ -104,4 +109,4 @@ class E3DCButton(CoordinatorEntity, ButtonEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
-        return self.coordinator.device_info()
+        return self._deviceInfo

--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -100,16 +100,18 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.debug("Wallbox with index %s has been found", wallbox_index)
 
                 unique_id = dr.format_mac(request_data["macAddress"])
+                wallboxType = request_data["wallboxType"]
+                model = f"Wallbox Type {wallboxType}"
 
                 deviceInfo = DeviceInfo(
                     identifiers={(DOMAIN, unique_id)},
                     via_device=(DOMAIN, self.uid),
                     manufacturer="E3DC",
                     name=request_data["deviceName"],
-                    model=request_data["wallboxType"],
-                    sw_version=request_data["appSoftware"],
-                    hw_version=request_data["hwVersion"],
+                    model=model,
+                    sw_version=request_data["firmwareVersion"],
                     serial_number=request_data["wallboxSerial"],
+                    connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(request_data["macAddress"]))},
                     configuration_url="https://my.e3dc.com/",
                 )
 
@@ -398,10 +400,11 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             manufacturer="E3DC",
             model=self.proxy.e3dc.model,
             name=self.proxy.e3dc.model,
+            serial_number=self.proxy.e3dc.serialNumber,
             connections={(dr.CONNECTION_NETWORK_MAC, self.proxy.e3dc.macAddress)},
             identifiers={(DOMAIN, self.uid)},
             sw_version=self._sw_version,
-            configuration_url="https://s10.e3dc.com/",
+            configuration_url="https://my.e3dc.com/",
         )
 
     async def async_set_weather_regulated_charge(self, enabled: bool) -> bool:

--- a/custom_components/e3dc_rscp/e3dc_proxy.py
+++ b/custom_components/e3dc_rscp/e3dc_proxy.py
@@ -169,11 +169,10 @@ class E3DCProxy:
                 "Container",
                 [
                     ("WB_INDEX", "UChar8", wallbox_index),
-                    ("WB_REQ_APP_SOFTWARE", "None", None),
+                    ("WB_REQ_FIRMWARE_VERSION", "None", None),
                     ("WB_REQ_MAC_ADDRESS", "None", None),
                     ("WB_REQ_DEVICE_NAME", "None", None),
                     ("WB_REQ_SERIAL", "None", None),
-                    ("WB_REQ_HW_VERSION", "None", None),
                     ("WB_REQ_WALLBOX_TYPE", "None", None),
                 ],
             ),
@@ -184,9 +183,9 @@ class E3DCProxy:
             "index": rscpFindTagIndex(req, "WB_INDEX"),
         }
 
-        app_software = rscpFindTag(req, "WB_APP_SOFTWARE")
-        if app_software is not None:
-            outObj["appSoftware"] = rscpFindTagIndex(app_software, "WB_APP_SOFTWARE")
+        firmware_version = rscpFindTag(req, "WB_FIRMWARE_VERSION")
+        if firmware_version is not None:
+            outObj["firmwareVersion"] = rscpFindTagIndex(firmware_version, "WB_FIRMWARE_VERSION")
 
         device_name = rscpFindTag(req, "WB_DEVICE_NAME")
         if device_name is not None:
@@ -195,10 +194,6 @@ class E3DCProxy:
         wallbox_serial = rscpFindTag(req, "WB_SERIAL")
         if wallbox_serial is not None:
             outObj["wallboxSerial"] = rscpFindTagIndex(wallbox_serial, "WB_SERIAL")
-
-        hw_version = rscpFindTag(req, "WB_HW_VERSION")
-        if hw_version is not None:
-            outObj["hwVersion"] = rscpFindTagIndex(hw_version, "WB_HW_VERSION")
 
         mac_address = rscpFindTag(req, "WB_MAC_ADDRESS")
         if mac_address is not None:

--- a/custom_components/e3dc_rscp/sensor.py
+++ b/custom_components/e3dc_rscp/sensor.py
@@ -420,46 +420,45 @@ async def async_setup_entry(
         entities.append(E3DCSensor(coordinator, power_description, entry.unique_id))
 
     for wallbox in coordinator.wallboxes:
+        # Get the UID & Key for the given wallbox
+        unique_id = list(wallbox["deviceInfo"]["identifiers"])[0][1]
+        wallbox_key = wallbox["key"]
 
         wallbox_app_software_description = SensorEntityDescription(
-            key=wallbox["key"] + "-app-software",
+            key=f"{wallbox_key}-app-software",
             translation_key="wallbox-app-software",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:information-outline",
             device_class=None,
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC
         )
-        entities.append(E3DCSensor(coordinator, wallbox_app_software_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_app_software_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_consumption_net_description = SensorEntityDescription(
-            key=wallbox["key"] + "-consumption-net",
+            key=f"{wallbox_key}-consumption-net",
             translation_key="wallbox-consumption-net",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:transmission-tower-import",
             native_unit_of_measurement=UnitOfPower.WATT,
             suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_consumption_net_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_consumption_net_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_consumption_sun_description = SensorEntityDescription(
-            key=wallbox["key"] + "-consumption-sun",
+            key=f"{wallbox_key}-consumption-sun",
             translation_key="wallbox-consumption-sun",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:solar-power",
             native_unit_of_measurement=UnitOfPower.WATT,
             suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_consumption_sun_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_consumption_sun_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_energy_all_description = SensorEntityDescription(
-            key=wallbox["key"] + "-energy-all",
+            key=f"{wallbox_key}-energy-all",
             translation_key="wallbox-energy-all",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:counter",
             native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -467,12 +466,11 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_energy_all_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_energy_all_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_energy_net_description = SensorEntityDescription(
-            key=wallbox["key"] + "-energy-net",
+            key=f"{wallbox_key}-energy-net",
             translation_key="wallbox-energy-net",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:counter",
             native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -480,12 +478,11 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_energy_net_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_energy_net_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_energy_sun_description = SensorEntityDescription(
-            key=wallbox["key"] + "-energy-sun",
+            key=f"{wallbox_key}-energy-sun",
             translation_key="wallbox-energy-sun",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:counter",
             native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             suggested_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -493,43 +490,39 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_energy_sun_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_energy_sun_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_index_description = SensorEntityDescription(
-            key=wallbox["key"] + "-index",
+            key=f"{wallbox_key}-index",
             translation_key="wallbox-index",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:numeric",
             device_class=None,
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC
         )
-        entities.append(E3DCSensor(coordinator, wallbox_index_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_index_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_max_charge_current_description = SensorEntityDescription(
-            key=wallbox["key"] + "-max-charge-current",
+            key=f"{wallbox_key}-max-charge-current",
             translation_key="wallbox-max-charge-current",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:current-ac",
             native_unit_of_measurement="A",
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_max_charge_current_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_max_charge_current_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_phases_description = SensorEntityDescription(
-            key=wallbox["key"] + "-phases",
+            key=f"{wallbox_key}-phases",
             translation_key="wallbox-phases",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:sine-wave",
             device_class=None,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_phases_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_phases_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_soc_description = SensorEntityDescription(
-            key=wallbox["key"] + "-soc",
+            key=f"{wallbox_key}-soc",
             translation_key="wallbox-soc",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             icon="mdi:battery-charging",
             native_unit_of_measurement=PERCENTAGE,
             suggested_display_precision=0,
@@ -537,7 +530,7 @@ async def async_setup_entry(
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_soc_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSensor(coordinator, wallbox_soc_description, unique_id, wallbox["deviceInfo"]))
 
 
     async_add_entities(entities)

--- a/custom_components/e3dc_rscp/sensor.py
+++ b/custom_components/e3dc_rscp/sensor.py
@@ -430,7 +430,7 @@ async def async_setup_entry(
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC
         )
-        entities.append(E3DCSensor(coordinator, wallbox_app_software_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_app_software_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_consumption_net_description = SensorEntityDescription(
             key=wallbox["key"] + "-consumption-net",
@@ -442,7 +442,7 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_consumption_net_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_consumption_net_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_consumption_sun_description = SensorEntityDescription(
             key=wallbox["key"] + "-consumption-sun",
@@ -454,7 +454,7 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_consumption_sun_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_consumption_sun_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_energy_all_description = SensorEntityDescription(
             key=wallbox["key"] + "-energy-all",
@@ -467,7 +467,7 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_energy_all_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_energy_all_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_energy_net_description = SensorEntityDescription(
             key=wallbox["key"] + "-energy-net",
@@ -480,7 +480,7 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_energy_net_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_energy_net_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_energy_sun_description = SensorEntityDescription(
             key=wallbox["key"] + "-energy-sun",
@@ -493,7 +493,7 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_energy_sun_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_energy_sun_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_index_description = SensorEntityDescription(
             key=wallbox["key"] + "-index",
@@ -504,7 +504,7 @@ async def async_setup_entry(
             entity_registry_enabled_default=False,
             entity_category=EntityCategory.DIAGNOSTIC
         )
-        entities.append(E3DCSensor(coordinator, wallbox_index_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_index_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_max_charge_current_description = SensorEntityDescription(
             key=wallbox["key"] + "-max-charge-current",
@@ -515,7 +515,7 @@ async def async_setup_entry(
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_max_charge_current_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_max_charge_current_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_phases_description = SensorEntityDescription(
             key=wallbox["key"] + "-phases",
@@ -524,7 +524,7 @@ async def async_setup_entry(
             icon="mdi:sine-wave",
             device_class=None,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_phases_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_phases_description, entry.unique_id, wallbox["deviceInfo"]))
 
         wallbox_soc_description = SensorEntityDescription(
             key=wallbox["key"] + "-soc",
@@ -537,7 +537,7 @@ async def async_setup_entry(
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         )
-        entities.append(E3DCSensor(coordinator, wallbox_soc_description, entry.unique_id))
+        entities.append(E3DCSensor(coordinator, wallbox_soc_description, entry.unique_id, wallbox["deviceInfo"]))
 
 
     async_add_entities(entities)
@@ -553,12 +553,17 @@ class E3DCSensor(CoordinatorEntity, SensorEntity):
         coordinator: E3DCCoordinator,
         description: SensorEntityDescription,
         uid: str,
+        device_info: DeviceInfo | None = None
     ) -> None:
         """Initialize the Sensor."""
         super().__init__(coordinator)
         self.coordinator: E3DCCoordinator = coordinator
         self.entity_description: SensorEntityDescription = description
         self._attr_unique_id = f"{uid}_{description.key}"
+        if device_info is not None:
+            self._deviceInfo = device_info
+        else:
+            self._deviceInfo = self.coordinator.device_info()
 
     @property
     def native_value(self) -> StateType:
@@ -568,4 +573,4 @@ class E3DCSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
-        return self.coordinator.device_info()
+        return self._deviceInfo

--- a/custom_components/e3dc_rscp/services.yaml
+++ b/custom_components/e3dc_rscp/services.yaml
@@ -45,15 +45,6 @@ set_wallbox_max_charge_current:
         device:
           filter:
             integration: e3dc_rscp
-    wallbox_index:
-      required: true
-      example: "0"
-      selector:
-        number:
-          min: 0
-          max: 7
-          mode: box
-          step: 1
     max_charge_current:
       required: false
       example: "16"

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -40,28 +40,28 @@
         "name": "Manual charge"
       },
       "wallbox-battery-to-car": {
-        "name": "{wallbox_name} battery to car"
+        "name": "Battery to car"
       },
       "wallbox-charging": {
-        "name": "{wallbox_name} charging"
+        "name": "Charging"
       },
       "wallbox-charging-canceled": {
-        "name": "{wallbox_name} charging canceled"
+        "name": "Charging canceled"
       },
       "wallbox-sun-mode": {
-        "name": "{wallbox_name} sun mode"
+        "name": "Sun mode"
       },
       "wallbox-plug-lock": {
-        "name": "{wallbox_name} plug lock"
+        "name": "Plug lock"
       },
       "wallbox-plug": {
-        "name": "{wallbox_name} plug"
+        "name": "Plug"
       },
       "wallbox-schuko": {
-        "name": "{wallbox_name} schuko"
+        "name": "Schuko"
       },
       "wallbox-key-state": {
-        "name": "{wallbox_name} key state"
+        "name": "Key state"
       }
     },
     "sensor": {
@@ -219,34 +219,34 @@
         "name": "Farm additional powermeter - total"
       },
       "wallbox-app-software": {
-        "name": "{wallbox_name} app software"
+        "name": "App software"
       },
       "wallbox-consumption-net": {
-        "name": "{wallbox_name} consumption net"
+        "name": "Consumption net"
       },
       "wallbox-consumption-sun": {
-        "name": "{wallbox_name} consumption sun"
+        "name": "Consumption sun"
       },
       "wallbox-energy-all": {
-        "name": "{wallbox_name} energy all"
+        "name": "Energy all"
       },
       "wallbox-energy-net": {
-        "name": "{wallbox_name} energy net"
+        "name": "Energy net"
       },
       "wallbox-energy-sun": {
-        "name": "{wallbox_name} energy sun"
+        "name": "Energy sun"
       },
       "wallbox-index": {
-        "name": "{wallbox_name} index"
+        "name": "Index"
       },
       "wallbox-max-charge-current": {
-        "name": "{wallbox_name} max charge current"
+        "name": "Max charge current"
       },
       "wallbox-phases": {
-        "name": "{wallbox_name} phases"
+        "name": "Phases"
       },
       "wallbox-soc": {
-        "name": "{wallbox_name} state of charge"
+        "name": "State of charge"
       }
     },
     "switch": {
@@ -257,18 +257,18 @@
         "name": "SmartPower powersaving"
       },
       "wallbox-sun-mode": {
-        "name": "{wallbox_name} sun mode"
+        "name": "Sun mode"
       },
       "wallbox-schuko": {
-        "name": "{wallbox_name} schuko"
+        "name": "Schuko"
       }
     },
     "button": {
       "wallbox-toggle-wallbox-charging": {
-        "name": "{wallbox_name} charging"
+        "name": "Charging"
       },
       "wallbox-toggle-wallbox-phases": {
-        "name": "{wallbox_name} phases"
+        "name": "Phases"
       }
     }
   },
@@ -308,10 +308,6 @@
         "device_id": {
           "name": "E3DC Device ID",
           "description": "E3DC Device ID, take it either from the YAML-Mode on the website of out of the URL of the device configuration page."
-        },
-        "wallbox_index": {
-          "name": "Wallbox Index",
-          "description": "Index of the Wallbox, You find it in the diagnostic entity of the wallbox \"Wallbox Index\" (deactivated by default)."
         },
         "max_charge_current": {
           "name": "Maximum Charging Current (A)",

--- a/custom_components/e3dc_rscp/switch.py
+++ b/custom_components/e3dc_rscp/switch.py
@@ -82,42 +82,43 @@ async def async_setup_entry(
     ]
 
     for wallbox in coordinator.wallboxes:
+        # Get the UID & Key for the given wallbox
+        unique_id = list(wallbox["deviceInfo"]["identifiers"])[0][1]
+        wallbox_key = wallbox["key"]
 
         wallbox_sun_mode_description = E3DCSwitchEntityDescription(
             # TODO: Figure out how the icons match the on/off state
-            key=wallbox["key"] + "-sun-mode",
+            key=f"{wallbox_key}-sun-mode",
             translation_key="wallbox-sun-mode",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             name="Wallbox Sun Mode",
             on_icon="mdi:weather-sunny",
             off_icon="mdi:weather-sunny-off",
             device_class=SwitchDeviceClass.SWITCH,
             async_turn_on_action=lambda coordinator: coordinator.async_set_wallbox_sun_mode(
-                True
+                True, wallbox["index"]
             ),
             async_turn_off_action=lambda coordinator: coordinator.async_set_wallbox_sun_mode(
-                False
+                False, wallbox["index"]
             ),
         )
-        entities.append(E3DCSwitch(coordinator, wallbox_sun_mode_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSwitch(coordinator, wallbox_sun_mode_description, unique_id, wallbox["deviceInfo"]))
 
         wallbox_schuko_description = E3DCSwitchEntityDescription(
-            key=wallbox["key"] + "-schuko",
+            key=f"{wallbox_key}-schuko",
             translation_key="wallbox-schuko",
-            translation_placeholders = {"wallbox_name": wallbox["name"]},
             name="Wallbox Schuko",
             on_icon="mdi:power-plug",
             off_icon="mdi:power-plug-off",
             device_class=SwitchDeviceClass.OUTLET,
             async_turn_on_action=lambda coordinator: coordinator.async_set_wallbox_schuko(
-                True
+                True, wallbox["index"]
             ),
             async_turn_off_action=lambda coordinator: coordinator.async_set_wallbox_schuko(
-                False
+                False, wallbox["index"]
             ),
             entity_registry_enabled_default=False, # Disabled per default as only Wallbox multi connect I provides this feature
         )
-        entities.append(E3DCSwitch(coordinator, wallbox_schuko_description, entry.unique_id, wallbox["deviceInfo"]))
+        entities.append(E3DCSwitch(coordinator, wallbox_schuko_description, unique_id, wallbox["deviceInfo"]))
 
     async_add_entities(entities)
 

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -40,28 +40,28 @@
                 "name": "Manual charge"
             },
             "wallbox-battery-to-car": {
-                "name": "{wallbox_name} battery to car"
+                "name": "Battery to car"
             },
             "wallbox-charging-canceled": {
-                "name": "{wallbox_name} charging canceled"
+                "name": "Charging canceled"
             },
             "wallbox-sun-mode": {
-                "name": "{wallbox_name} sun mode"
+                "name": "Sun mode"
             },
             "wallbox-key-state": {
-                "name": "{wallbox_name} key state"
+                "name": "Key state"
             },
             "wallbox-plug-lock": {
-                "name": "{wallbox_name} plug lock"
+                "name": "Plug lock"
             },
             "wallbox-plug": {
-                "name": "{wallbox_name} plug"
+                "name": "Plug"
             },
             "wallbox-schuko": {
-                "name": "{wallbox_name} schuko"
+                "name": "Schuko"
             },
             "wallbox-charging": {
-                "name": "{wallbox_name} charging"
+                "name": "Charging"
             }
         },
         "sensor": {
@@ -219,34 +219,34 @@
                 "name": "Farm additional powermeter - total"
             },
             "wallbox-app-software": {
-                "name": "{wallbox_name} app software"
+                "name": "App software"
             },
             "wallbox-consumption-net": {
-                "name": "{wallbox_name} consumption net"
+                "name": "Consumption net"
             },
             "wallbox-consumption-sun": {
-                "name": "{wallbox_name} consumption sun"
+                "name": "Consumption sun"
             },
             "wallbox-energy-all": {
-                "name": "{wallbox_name} energy all"
+                "name": "Energy all"
             },
             "wallbox-energy-net": {
-                "name": "{wallbox_name} energy net"
+                "name": "Energy net"
             },
             "wallbox-energy-sun": {
-                "name": "{wallbox_name} energy sun"
+                "name": "Energy sun"
             },
             "wallbox-index": {
-                "name": "{wallbox_name} index"
+                "name": "Index"
             },
             "wallbox-max-charge-current": {
-                "name": "{wallbox_name} max charge current"
+                "name": "Max charge current"
             },
             "wallbox-phases": {
-                "name": "{wallbox_name} phases"
+                "name": "Phases"
             },
             "wallbox-soc": {
-                "name": "{wallbox_name} state of charge"
+                "name": "State of charge"
             }
         },
         "switch": {
@@ -257,18 +257,18 @@
                 "name": "SmartPower powersaving"
             },
             "wallbox-sun-mode": {
-                "name": "{wallbox_name} sun mode"
+                "name": "Sun mode"
             },
             "wallbox-schuko": {
-                "name": "{wallbox_name} schuko"
+                "name": "Schuko"
             }
         },
         "button": {
             "wallbox-toggle-wallbox-charging": {
-                "name": "{wallbox_name} charging"
+                "name": "Charging"
             },
             "wallbox-toggle-wallbox-phases": {
-                "name": "{wallbox_name} phases"
+                "name": "Phases"
             }
         }
     },
@@ -308,10 +308,6 @@
                 "device_id": {
                     "name": "E3DC Device ID",
                     "description": "E3DC Device ID, take it either from the YAML-Mode on the website of out of the URL of the device configuration page."
-                },
-                "wallbox_index": {
-                    "name": "Wallbox Index",
-                    "description": "Index of the Wallbox, You find it in the diagnostic entity of the wallbox \"Wallbox Index\" (deactivated by default)."
                 },
                 "max_charge_current": {
                     "name": "Maximum Charging Current (A)",


### PR DESCRIPTION
Wallboxes are now separate devices.
This brought a lot of changes in entity names, entity keys, unique IDs, etc.

In order to identify the wallboxes properly, it was necessary to retrieve info such as the MAC adress directly from python-e3dc via RSCP.

Functionality has been verified with one real wallbox and a couple of dummy WBs.

First feedback/bugs from the BETA release has been incorporated as well.

