### PR TITLE
Made _resolve_device_id more robust when following via_devices

### DIFF
--- a/custom_components/e3dc_rscp/services.py
+++ b/custom_components/e3dc_rscp/services.py
@@ -114,15 +114,20 @@ def _resolve_device_id(hass: HomeAssistant, devid: str) -> E3DCCoordinator:
             f"{SERVICE_SET_POWER_LIMITS}: Unkown device ID {devid}."
         )
 
-    if dev.via_device_id is not None:
-        dev = dev_reg.async_get(dev.via_device_id)
-        if dev is None:
-            raise HomeAssistantError(
-                f"{SERVICE_SET_POWER_LIMITS}: Unkown device ID {devid}."
-            )
-
-    identifier: tuple(str, str)  # = next(iter(dev.identifiers))
+    identifier: tuple(str, str)
     uid: str | None = None
+
+    # Follow the via device and make it the new device if it is an E3DC
+    if dev.via_device_id is not None:
+        via_dev = dev_reg.async_get(dev.via_device_id)
+        if via_dev is None:
+            raise HomeAssistantError(
+                f"{SERVICE_SET_POWER_LIMITS}: Invalid via Device ID {devid}."
+            )
+        for identifier in via_dev.identifiers:
+            domain: str = identifier[0]
+        if domain == DOMAIN:
+            dev = via_dev
 
     for identifier in dev.identifiers:
         domain: str = identifier[0]


### PR DESCRIPTION
Fixed that for some users calling E3DC services resulted in a "Device <Device-ID> is no E3DC"-Error.

**Root cause:**
Other (Non-E3DC) devices from other integrations can be a [via_device](https://developers.home-assistant.io/docs/device_registry_index/) for the E3DC.
When introducing the wallbox devices, i added the functionality in _resolve_device_id() to follow the via_device to come from the wallbox to the E3DC Hauskraftwerk. However when following the via_device, there was no additional check if the upstream-device was also in the E3DC domain.
This led in my case e.g. that the service tried to call my Fritz!Box.

**Fix:**
Only follow the via_device if it's type is also E3DC.