### PR TITLE
Wallbox release fixes

### DIFF
--- a/custom_components/e3dc_rscp/button.py
+++ b/custom_components/e3dc_rscp/button.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
             key=f"{wallbox_key}-toggle-wallbox-phases",
             translation_key="wallbox-toggle-wallbox-phases",
             icon="mdi:sine-wave",
-            async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_phases(wallbox["index"]),
+            async_press_action=lambda coordinator, index=wallbox["index"]: coordinator.async_toggle_wallbox_phases(index),
         )
         entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_phases_description, unique_id, wallbox["deviceInfo"]))
 
@@ -63,7 +63,7 @@ async def async_setup_entry(
             key=f"{wallbox_key}-toggle-wallbox-charging",
             translation_key="wallbox-toggle-wallbox-charging",
             icon="mdi:car-electric",
-            async_press_action=lambda coordinator: coordinator.async_toggle_wallbox_charging(wallbox["index"]),
+            async_press_action=lambda coordinator, index=wallbox["index"]: coordinator.async_toggle_wallbox_charging(index),
         )
         entities.append(E3DCButton(coordinator, wallbox_toggle_wallbox_charging_description, unique_id, wallbox["deviceInfo"]))
 

--- a/custom_components/e3dc_rscp/sensor.py
+++ b/custom_components/e3dc_rscp/sensor.py
@@ -185,17 +185,6 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
-        key="wallbox-consumption",
-        translation_key="wallbox-consumption",
-        icon="mdi:ev-station",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
-        suggested_display_precision=2,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=False,
-    ),
-    SensorEntityDescription(
         key="grid-netchange",
         translation_key="grid-netchange",
         icon="mdi:battery-charging",
@@ -532,6 +521,18 @@ async def async_setup_entry(
         )
         entities.append(E3DCSensor(coordinator, wallbox_soc_description, unique_id, wallbox["deviceInfo"]))
 
+    if len(coordinator.wallboxes) > 0:
+        wallbox_consumption_description = SensorEntityDescription(
+            key="wallbox-consumption",
+            translation_key="wallbox-consumption",
+            icon="mdi:ev-station",
+            native_unit_of_measurement=UnitOfPower.WATT,
+            suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
+            suggested_display_precision=2,
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+        )
+        entities.append(E3DCSensor(coordinator, wallbox_consumption_description, entry.unique_id))
 
     async_add_entities(entities)
 

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -265,10 +265,10 @@
     },
     "button": {
       "wallbox-toggle-wallbox-charging": {
-        "name": "Charging"
+        "name": "Toggle charging"
       },
       "wallbox-toggle-wallbox-phases": {
-        "name": "Phases"
+        "name": "Toggle phases"
       }
     },
     "number": {

--- a/custom_components/e3dc_rscp/switch.py
+++ b/custom_components/e3dc_rscp/switch.py
@@ -94,12 +94,8 @@ async def async_setup_entry(
             on_icon="mdi:weather-sunny",
             off_icon="mdi:weather-sunny-off",
             device_class=SwitchDeviceClass.SWITCH,
-            async_turn_on_action=lambda coordinator: coordinator.async_set_wallbox_sun_mode(
-                True, wallbox["index"]
-            ),
-            async_turn_off_action=lambda coordinator: coordinator.async_set_wallbox_sun_mode(
-                False, wallbox["index"]
-            ),
+            async_turn_on_action=lambda coordinator, index=wallbox["index"]: coordinator.async_set_wallbox_sun_mode(True, index),
+            async_turn_off_action=lambda coordinator, index=wallbox["index"]: coordinator.async_set_wallbox_sun_mode(False, index),
         )
         entities.append(E3DCSwitch(coordinator, wallbox_sun_mode_description, unique_id, wallbox["deviceInfo"]))
 
@@ -110,12 +106,8 @@ async def async_setup_entry(
             on_icon="mdi:power-plug",
             off_icon="mdi:power-plug-off",
             device_class=SwitchDeviceClass.OUTLET,
-            async_turn_on_action=lambda coordinator: coordinator.async_set_wallbox_schuko(
-                True, wallbox["index"]
-            ),
-            async_turn_off_action=lambda coordinator: coordinator.async_set_wallbox_schuko(
-                False, wallbox["index"]
-            ),
+            async_turn_on_action=lambda coordinator, index=wallbox["index"]: coordinator.async_set_wallbox_schuko(True, index),
+            async_turn_off_action=lambda coordinator, index=wallbox["index"]: coordinator.async_set_wallbox_schuko(False, index),
             entity_registry_enabled_default=False, # Disabled per default as only Wallbox multi connect I provides this feature
         )
         entities.append(E3DCSwitch(coordinator, wallbox_schuko_description, unique_id, wallbox["deviceInfo"]))

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -265,10 +265,10 @@
         },
         "button": {
             "wallbox-toggle-wallbox-charging": {
-                "name": "Charging"
+                "name": "Toggle charging"
             },
             "wallbox-toggle-wallbox-phases": {
-                "name": "Phases"
+                "name": "Toggle phases"
             }
         },
         "number": {


### PR DESCRIPTION
Fixes based on 3.8 Beta 4 included (so far):
- Erroneous Lambda-Functions when calling Services (Bug was introduced when adding wallbox as a device)
- Wallbox Consumption is now a) only available if a Wallbox is installed b) enabled by default 