### PR TITLE
Make SG Ready sensor an enum sensor with selectable states

### DIFF
--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -494,7 +494,14 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.warning("Failed to load SG Ready state, not updating data: %s", ex)
             return
 
-        self._mydata["sgready-state"] = request_data["sgready-state"]
+        sgready_state_map = {
+            1: "locked",
+            2: "normal",
+            3: "released",
+            4: "start_up",
+        }
+        raw_state = request_data["sgready-state"]
+        self._mydata["sgready-state"] = sgready_state_map.get(raw_state, str(raw_state))
         self._mydata["sgready-numeric-state"] = request_data["sgready-numeric-state"]
         self._mydata["sgready-active"] = bool(request_data["sgready-active"])
         self._sgready_available = bool(request_data["sgready-active"])

--- a/custom_components/e3dc_rscp/sensor.py
+++ b/custom_components/e3dc_rscp/sensor.py
@@ -864,6 +864,8 @@ async def async_setup_entry(
             key="sgready-state",
             translation_key="sgready-state",
             icon="mdi:heat-pump",
+            device_class=SensorDeviceClass.ENUM,
+            options=["locked", "normal", "released", "start_up"],
         )
         entities.append(
             E3DCSensor(coordinator, sgready_state_description, entry.unique_id)

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -393,10 +393,10 @@
       "sgready-state": {
         "name": "SG Ready",
         "state": {
-          "1": "Locked",
-          "2": "Normal",
-          "3": "Released",
-          "4": "Start-up"
+          "locked": "Locked",
+          "normal": "Normal",
+          "released": "Released",
+          "start_up": "Start-up"
         }
       },
       "sgready-numeric-state": {

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -468,10 +468,10 @@
             "sgready-state": {
                 "name": "SG Ready",
                 "state": {
-                    "1": "Locked",
-                    "2": "Normal",
-                    "3": "Released",
-                    "4": "Start-up"
+                    "locked": "Locked",
+                    "normal": "Normal",
+                    "released": "Released",
+                    "start_up": "Start-up"
                 }
             },
             "sgready-numeric-state": {


### PR DESCRIPTION
Converts the sgready-state sensor to use SensorDeviceClass.ENUM with proper options, so Home Assistant automation UI shows a dropdown with the available states (Locked, Normal, Released, Start-up) instead of requiring users to manually type numeric values.

- Map raw numeric RSCP values (1-4) to string keys in coordinator
- Add device_class=ENUM and options to sensor description
- Update strings.json and translations with string-based state keys

Fixes #314
