### PR TITLE
Add authentication type selector (Portal-User vs Local user) and reconfigure flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,33 @@ control, use the manual installation method.
 
 ## Configuration
 
-Once you add the integration, you'll be asked to authenticate yourself for a
-local connection to your E3DC.
+When you add the integration, you first choose the authentication type:
+
+- **Portal-User:** Use your E3DC portal account (email address + portal password).
+- **Local user:** Use the offline RSCP account on the device. The username is fixed to **local.user** and is filled in automatically by the integration.
+
+For a manual setup, the integration asks for:
+
+- **Hostname:** The hostname or IP address of the E3/DC system
+- **Password:**
+  - for **Portal-User**: your E3DC portal password
+  - for **Local user**: the password configured on the device under *Main Page -> Personalize -> User profile -> Password for offline RSCP user*
+- **RSCP Password:** This is the encryption key used in RSCP communications. You
+  have to set it on the device under *Main Page -> Personalize -> User profile ->
+  RSCP password.*
+
+If you choose **Portal-User**, you also need:
+
+- **Username:** Your E3DC portal user name / email address
 
 E3DC can be auto-discovered by Home Assistant. If an instance was found, it
 will be shown as discovered. You can then set it up right away. In that case no
 hostname has to be provided.
 
-- **Username:** Your E3DC portal user name
-- **Password:** Your E3DC portal password
-- **Hostname:** The Hostname or IP address of the E3/DC system
-- **RSCP Password:** This is the encryption key used in RSCP communications. You
-  have to set on the device under *Main Page -> Personalize -> User profile ->
-  RSCP password.*
+Please note: the discovery flow currently uses the portal credentials flow.
+
+Existing installations can update or switch their authentication method later
+via the integration's reconfigure flow in Home Assistant.
 
 If you have multiple E3DC instances configured as a farm, the integration will detect
 the farming controller after configuring the first child of the farm and add it to the
@@ -172,7 +186,6 @@ tcp:
 Currently, the following features of pye3dc are not supported:
 
 - Web Connections
-- Local connections when offline, using the backup user.
 
 ## Actions
 

--- a/custom_components/e3dc_rscp/config_flow.py
+++ b/custom_components/e3dc_rscp/config_flow.py
@@ -27,6 +27,9 @@ from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
 )
 
 from custom_components.e3dc_rscp.utils import initialize_farm_controller_flow_if_needed
@@ -44,15 +47,41 @@ from .const import (
     DOMAIN,
     ERROR_AUTH_INVALID,
     ERROR_CANNOT_CONNECT,
+    CONF_AUTH_TYPE,
+    AUTH_TYPE_CLOUD,
+    AUTH_TYPE_LOCAL,
+    LOCAL_USERNAME,
 )
 from .e3dc_proxy import E3DCProxy
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
+STEP_AUTH_TYPE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_AUTH_TYPE, default=AUTH_TYPE_CLOUD): SelectSelector(
+            SelectSelectorConfig(
+                options=[AUTH_TYPE_CLOUD, AUTH_TYPE_LOCAL],
+                mode=SelectSelectorMode.LIST,
+                translation_key="auth_type",
+            )
+        ),
+    }
+)
+
+STEP_CREDENTIALS_CLOUD_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_RSCPKEY): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
+    }
+)
+
+STEP_CREDENTIALS_LOCAL_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_RSCPKEY): TextSelector(
             TextSelectorConfig(type=TextSelectorType.PASSWORD)
@@ -76,6 +105,7 @@ class E3DCConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self._port: int | None = None
         self._proxy: E3DCProxy = None
         self._discovered_info: dict[str, Any] | None = None
+        self._auth_type: str = AUTH_TYPE_CLOUD
 
     def _async_check_login(self) -> None:
         """Check the login credentials."""
@@ -106,26 +136,48 @@ class E3DCConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
-        errors: dict[str, str] = {}
+        """Step 1 of initial setup: choose authentication type."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=STEP_AUTH_TYPE_SCHEMA,
+            )
+
+        self._auth_type = user_input.get(CONF_AUTH_TYPE, AUTH_TYPE_CLOUD)
+        return await self.async_step_credentials()
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 2 of initial setup: collect credentials for the chosen auth type."""
+        schema = (
+            STEP_CREDENTIALS_LOCAL_SCHEMA
+            if self._auth_type == AUTH_TYPE_LOCAL
+            else STEP_CREDENTIALS_CLOUD_SCHEMA
+        )
 
         if user_input is None:
-            return self._show_setup_form_init(errors)
+            return self._show_credentials_form(schema)
 
         self._host = user_input[CONF_HOST]
-        self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
         self._rscpkey = user_input[CONF_RSCPKEY]
         self._port = user_input.get(CONF_PORT, None)
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            self._username = LOCAL_USERNAME
+        else:
+            self._username = user_input[CONF_USERNAME]
 
         if error := await self.validate_input():
-            return self._show_setup_form_init({"base": error})
+            return self._show_credentials_form(schema, {"base": error})
 
         await self.async_set_unique_id(
             f"{self._proxy.e3dc.serialNumberPrefix}{self._proxy.e3dc.serialNumber}"
         )
         self._abort_if_unique_id_configured()
-        final_data: dict[str, Any] = user_input
+        final_data: dict[str, Any] = dict(user_input)
+        final_data[CONF_USERNAME] = self._username
+        final_data[CONF_AUTH_TYPE] = self._auth_type
         final_data[CONF_FARMCONTROLLER] = len(self._proxy.e3dc.serialNumber) >= 6 and self._proxy.e3dc.serialNumber[-6] == "1"
         final_data[CONF_API_VERSION] = CONF_VERSION
 
@@ -134,11 +186,25 @@ class E3DCConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             data=final_data,
         )
 
+    def _show_credentials_form(
+        self, schema, errors: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Show the credentials form, with the username hint for local user."""
+        placeholders = {}
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            placeholders["username"] = LOCAL_USERNAME
+        return self.async_show_form(
+            step_id="credentials",
+            data_schema=schema,
+            errors=errors or {},
+            description_placeholders=placeholders,
+        )
+
     def _show_setup_form_init(self, errors: dict[str, str] | None = None) -> FlowResult:
-        """Show the setup form to the user."""
+        """Show the auth-type selector form (used by error re-entry paths)."""
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=STEP_AUTH_TYPE_SCHEMA,
             errors=errors or {},
         )
 
@@ -146,45 +212,207 @@ class E3DCConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle flow upon API authentication errors."""
         self._entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         self._host = entry_data[CONF_HOST]
-        self._username = entry_data[CONF_USERNAME]
+        self._username = entry_data.get(CONF_USERNAME)
         self._password = entry_data[CONF_PASSWORD]
         self._rscpkey = entry_data[CONF_RSCPKEY]
+        self._auth_type = entry_data.get(CONF_AUTH_TYPE, AUTH_TYPE_CLOUD)
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Inform the user that a reauth is required."""
-
+        """Step 1 of reauth: choose authentication type."""
         if user_input is None:
             return self._show_setup_form_reauth_confirm()
 
+        self._auth_type = user_input.get(CONF_AUTH_TYPE, AUTH_TYPE_CLOUD)
+        return await self.async_step_reauth_credentials()
+
+    async def async_step_reauth_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 2 of reauth: collect credentials."""
+        schema = (
+            STEP_CREDENTIALS_LOCAL_SCHEMA
+            if self._auth_type == AUTH_TYPE_LOCAL
+            else STEP_CREDENTIALS_CLOUD_SCHEMA
+        )
+
+        if user_input is None:
+            return self._show_reauth_credentials_form(schema)
+
         self._host = user_input[CONF_HOST]
-        self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
         self._rscpkey = user_input[CONF_RSCPKEY]
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            self._username = LOCAL_USERNAME
+        else:
+            self._username = user_input[CONF_USERNAME]
 
         if error := await self.validate_input():
-            return self._show_setup_form_reauth_confirm({"base": error})
+            return self._show_reauth_credentials_form(schema, {"base": error})
 
         assert isinstance(self._entry, config_entries.ConfigEntry)
-        final_data: dict[str, Any] = user_input
-        final_data[CONF_API_VERSION] = CONF_VERSION
-        self.hass.config_entries.async_update_entry(
-            self._entry,
-            data=final_data,
-        )
+        new_data = dict(self._entry.data)
+        new_data[CONF_HOST] = self._host
+        new_data[CONF_USERNAME] = self._username
+        new_data[CONF_PASSWORD] = self._password
+        new_data[CONF_RSCPKEY] = self._rscpkey
+        new_data[CONF_AUTH_TYPE] = self._auth_type
+        new_data[CONF_API_VERSION] = CONF_VERSION
+        self.hass.config_entries.async_update_entry(self._entry, data=new_data)
         await self.hass.config_entries.async_reload(self._entry.entry_id)
         return self.async_abort(reason="reauth_successful")
+
+    def _show_reauth_credentials_form(
+        self, schema, errors: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Show the reauth credentials form."""
+        placeholders = {}
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            placeholders["username"] = LOCAL_USERNAME
+        return self.async_show_form(
+            step_id="reauth_credentials",
+            data_schema=schema,
+            errors=errors or {},
+            description_placeholders=placeholders,
+        )
 
     def _show_setup_form_reauth_confirm(
         self, errors: dict[str, str] | None = None
     ) -> FlowResult:
-        """Show the setup form to the user."""
+        """Show the reauth auth-type selector form."""
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_AUTH_TYPE, default=self._auth_type
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[AUTH_TYPE_CLOUD, AUTH_TYPE_LOCAL],
+                        mode=SelectSelectorMode.LIST,
+                        translation_key="auth_type",
+                    )
+                ),
+            }
+        )
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=schema,
             errors=errors or {},
+        )
+
+    # ------------------------------------------------------------------
+    # Reconfigure flow (three-dot menu -> "Reconfigure")
+    # ------------------------------------------------------------------
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 1 of reconfigure: choose authentication type."""
+        self._entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if self._entry is not None:
+            self._host = self._entry.data.get(CONF_HOST)
+            self._username = self._entry.data.get(CONF_USERNAME)
+            self._password = self._entry.data.get(CONF_PASSWORD)
+            self._rscpkey = self._entry.data.get(CONF_RSCPKEY)
+            self._port = self._entry.data.get(CONF_PORT)
+            self._auth_type = self._entry.data.get(
+                CONF_AUTH_TYPE, AUTH_TYPE_CLOUD
+            )
+
+        if user_input is None:
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_AUTH_TYPE, default=self._auth_type
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[AUTH_TYPE_CLOUD, AUTH_TYPE_LOCAL],
+                            mode=SelectSelectorMode.LIST,
+                            translation_key="auth_type",
+                        )
+                    ),
+                }
+            )
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=schema,
+            )
+
+        self._auth_type = user_input.get(CONF_AUTH_TYPE, AUTH_TYPE_CLOUD)
+        return await self.async_step_reconfigure_credentials()
+
+    async def async_step_reconfigure_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step 2 of reconfigure: collect credentials, pre-filled."""
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=self._host or ""): str,
+                    vol.Required(CONF_PASSWORD, default=self._password or ""): str,
+                    vol.Required(
+                        CONF_RSCPKEY, default=self._rscpkey or ""
+                    ): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            )
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=self._host or ""): str,
+                    vol.Required(
+                        CONF_USERNAME, default=self._username or ""
+                    ): str,
+                    vol.Required(CONF_PASSWORD, default=self._password or ""): str,
+                    vol.Required(
+                        CONF_RSCPKEY, default=self._rscpkey or ""
+                    ): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            )
+
+        if user_input is None:
+            return self._show_reconfigure_credentials_form(schema)
+
+        self._host = user_input[CONF_HOST]
+        self._password = user_input[CONF_PASSWORD]
+        self._rscpkey = user_input[CONF_RSCPKEY]
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            self._username = LOCAL_USERNAME
+        else:
+            self._username = user_input[CONF_USERNAME]
+
+        if error := await self.validate_input():
+            return self._show_reconfigure_credentials_form(schema, {"base": error})
+
+        assert isinstance(self._entry, config_entries.ConfigEntry)
+        new_data = dict(self._entry.data)
+        new_data[CONF_HOST] = self._host
+        new_data[CONF_USERNAME] = self._username
+        new_data[CONF_PASSWORD] = self._password
+        new_data[CONF_RSCPKEY] = self._rscpkey
+        new_data[CONF_AUTH_TYPE] = self._auth_type
+        new_data[CONF_API_VERSION] = CONF_VERSION
+        self.hass.config_entries.async_update_entry(self._entry, data=new_data)
+        await self.hass.config_entries.async_reload(self._entry.entry_id)
+        return self.async_abort(reason="reconfigure_successful")
+
+    def _show_reconfigure_credentials_form(
+        self, schema, errors: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Show the reconfigure credentials form."""
+        placeholders = {}
+        if self._auth_type == AUTH_TYPE_LOCAL:
+            placeholders["username"] = LOCAL_USERNAME
+        return self.async_show_form(
+            step_id="reconfigure_credentials",
+            data_schema=schema,
+            errors=errors or {},
+            description_placeholders=placeholders,
         )
 
     async def async_step_ssdp(

--- a/custom_components/e3dc_rscp/const.py
+++ b/custom_components/e3dc_rscp/const.py
@@ -6,6 +6,10 @@ from homeassistant.const import Platform
 CONF_RSCPKEY = "rscpkey"
 CONF_FARMCONTROLLER = "farmcontroller"
 CONF_VERSION = 2
+CONF_AUTH_TYPE = "auth_type"
+AUTH_TYPE_CLOUD = "cloud"
+AUTH_TYPE_LOCAL = "local"
+LOCAL_USERNAME = "local.user"
 DOMAIN = "e3dc_rscp"
 ERROR_AUTH_INVALID = "invalid_auth"
 ERROR_CANNOT_CONNECT = "cannot_connect"

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -1,21 +1,82 @@
 {
   "config": {
     "step": {
-      "reauth_confirm": {
-        "title": "Updating E3DC credentials",
+      "user": {
+        "title": "E3DC authentication type",
+        "description": "Choose how to authenticate with your E3DC device.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "rscpkey": "RSCP encryption key"
+          "auth_type": "Authentication type"
+        },
+        "data_description": {
+          "auth_type": "Portal-User: Use your E3DC portal account (email + password). Local user: Use the offline RSCP user (username is fixed to 'local.user', password configured on the device under Personalize \u2192 User profile \u2192 Password for offline RSCP user)."
         }
       },
-      "user": {
+      "credentials": {
+        "title": "E3DC credentials",
+        "description": "Enter the connection details.\n\nFor local user: the username will be set automatically to **local.user**.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
+          "host": "Host or IP address",
+          "username": "Username (E3DC portal email)",
+          "password": "Password",
           "rscpkey": "RSCP encryption key"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the E3DC device on your local network (e.g. 192.168.1.100).",
+          "username": "Your E3DC portal email address (only for Portal-User).",
+          "password": "Portal-User: your E3DC portal password.\nLocal user: the offline RSCP user password set on the device (Personalize \u2192 User profile \u2192 Password for offline RSCP user).",
+          "rscpkey": "The RSCP encryption key configured on the device (Personalize \u2192 User profile \u2192 RSCP password). This is the encryption key, not a login password."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Updating E3DC credentials",
+        "description": "Choose how to authenticate with your E3DC device.",
+        "data": {
+          "auth_type": "Authentication type"
+        },
+        "data_description": {
+          "auth_type": "Portal-User: Use your E3DC portal account. Local user: offline RSCP user (username: local.user)."
+        }
+      },
+      "reauth_credentials": {
+        "title": "Updating E3DC credentials",
+        "description": "Enter the connection details.\n\nFor local user: the username will be set automatically to **local.user**.",
+        "data": {
+          "host": "Host or IP address",
+          "username": "Username (E3DC portal email)",
+          "password": "Password",
+          "rscpkey": "RSCP encryption key"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the E3DC device on your local network (e.g. 192.168.1.100).",
+          "username": "Your E3DC portal email address (only for Portal-User).",
+          "password": "Portal-User: your E3DC portal password.\nLocal user: the offline RSCP user password set on the device.",
+          "rscpkey": "The RSCP encryption key configured on the device (Personalize \u2192 User profile \u2192 RSCP password)."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure E3DC",
+        "description": "Change authentication method or update credentials.",
+        "data": {
+          "auth_type": "Authentication type"
+        },
+        "data_description": {
+          "auth_type": "Portal-User: Use your E3DC portal account. Local user: offline RSCP user (username: local.user)."
+        }
+      },
+      "reconfigure_credentials": {
+        "title": "Reconfigure E3DC credentials",
+        "description": "Update the connection details.\n\nFor local user: the username will be set automatically to **local.user**.",
+        "data": {
+          "host": "Host or IP address",
+          "username": "Username (E3DC portal email)",
+          "password": "Password",
+          "rscpkey": "RSCP encryption key"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the E3DC device on your local network (e.g. 192.168.1.100).",
+          "username": "Your E3DC portal email address (only for Portal-User).",
+          "password": "Portal-User: your E3DC portal password.\nLocal user: the offline RSCP user password set on the device.",
+          "rscpkey": "The RSCP encryption key configured on the device (Personalize \u2192 User profile \u2192 RSCP password)."
         }
       },
       "discovery_confirm": {
@@ -34,7 +95,16 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    }
+  },
+  "selector": {
+    "auth_type": {
+      "options": {
+        "cloud": "Portal-User",
+        "local": "Local user (local.user)"
+      }
     }
   },
   "options": {

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -2,28 +2,90 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication"
         },
         "step": {
-            "reauth_confirm": {
-                "data": {
-                    "host": "Host",
-                    "password": "Password",
-                    "rscpkey": "RSCP encryption key",
-                    "username": "Username"
-                },
-                "title": "Updating E3DC credentials"
-            },
             "user": {
+                "title": "E3DC authentication type",
+                "description": "Choose how to authenticate with your E3DC device.",
                 "data": {
-                    "host": "Host",
+                    "auth_type": "Authentication type"
+                },
+                "data_description": {
+                    "auth_type": "Portal-User: Use your E3DC portal account (email + password). Local user: Use the offline RSCP user (username is fixed to 'local.user', password configured on the device under Personalize \u2192 User profile \u2192 Password for offline RSCP user)."
+                }
+            },
+            "credentials": {
+                "title": "E3DC credentials",
+                "description": "Enter the connection details.\n\nFor local user: the username will be set automatically to **local.user**.",
+                "data": {
+                    "host": "Host or IP address",
+                    "username": "Username (E3DC portal email)",
                     "password": "Password",
-                    "rscpkey": "RSCP encryption key",
-                    "username": "Username"
+                    "rscpkey": "RSCP encryption key"
+                },
+                "data_description": {
+                    "host": "IP address or hostname of the E3DC device on your local network (e.g. 192.168.1.100).",
+                    "username": "Your E3DC portal email address (only for Portal-User).",
+                    "password": "Portal-User: your E3DC portal password.\nLocal user: the offline RSCP user password set on the device (Personalize \u2192 User profile \u2192 Password for offline RSCP user).",
+                    "rscpkey": "The RSCP encryption key configured on the device (Personalize \u2192 User profile \u2192 RSCP password). This is the encryption key, not a login password."
+                }
+            },
+            "reauth_confirm": {
+                "title": "Updating E3DC credentials",
+                "description": "Choose how to authenticate with your E3DC device.",
+                "data": {
+                    "auth_type": "Authentication type"
+                },
+                "data_description": {
+                    "auth_type": "Portal-User: Use your E3DC portal account. Local user: offline RSCP user (username: local.user)."
+                }
+            },
+            "reauth_credentials": {
+                "title": "Updating E3DC credentials",
+                "description": "Enter the connection details.\n\nFor local user: the username will be set automatically to **local.user**.",
+                "data": {
+                    "host": "Host or IP address",
+                    "username": "Username (E3DC portal email)",
+                    "password": "Password",
+                    "rscpkey": "RSCP encryption key"
+                },
+                "data_description": {
+                    "host": "IP address or hostname of the E3DC device on your local network (e.g. 192.168.1.100).",
+                    "username": "Your E3DC portal email address (only for Portal-User).",
+                    "password": "Portal-User: your E3DC portal password.\nLocal user: the offline RSCP user password set on the device.",
+                    "rscpkey": "The RSCP encryption key configured on the device (Personalize \u2192 User profile \u2192 RSCP password)."
+                }
+            },
+            "reconfigure": {
+                "title": "Reconfigure E3DC",
+                "description": "Change authentication method or update credentials.",
+                "data": {
+                    "auth_type": "Authentication type"
+                },
+                "data_description": {
+                    "auth_type": "Portal-User: Use your E3DC portal account. Local user: offline RSCP user (username: local.user)."
+                }
+            },
+            "reconfigure_credentials": {
+                "title": "Reconfigure E3DC credentials",
+                "description": "Update the connection details.\n\nFor local user: the username will be set automatically to **local.user**.",
+                "data": {
+                    "host": "Host or IP address",
+                    "username": "Username (E3DC portal email)",
+                    "password": "Password",
+                    "rscpkey": "RSCP encryption key"
+                },
+                "data_description": {
+                    "host": "IP address or hostname of the E3DC device on your local network (e.g. 192.168.1.100).",
+                    "username": "Your E3DC portal email address (only for Portal-User).",
+                    "password": "Portal-User: your E3DC portal password.\nLocal user: the offline RSCP user password set on the device.",
+                    "rscpkey": "The RSCP encryption key configured on the device (Personalize \u2192 User profile \u2192 RSCP password)."
                 }
             },
             "discovery_confirm": {
@@ -44,6 +106,14 @@
                     "create_battery_devices": "Create battery devices"
                 },
                 "title": "E3DC RSCP options"
+            }
+        }
+    },
+    "selector": {
+        "auth_type": {
+            "options": {
+                "cloud": "Portal-User",
+                "local": "Local user (local.user)"
             }
         }
     },


### PR DESCRIPTION
## Summary

Adds a clear authentication-type selector to the config flow and a new reconfigure flow so users can switch auth method or update credentials without removing the integration.

The change is purely on the UI / config-flow side. `e3dc_proxy.py` and the rest of the runtime are unchanged.

## Motivation

The E3DC RSCP interface accepts two kinds of accounts:

1. **Portal account** (E3DC web portal credentials, email + password)
2. **Offline RSCP local user** (fixed username `local.user`, separate password configured on the device under *Personalize → User profile → Password for offline RSCP user*)

Today's single config form just asks for "Username" and "Password", which is confusing for users who want to use the local account (they don't always know the username has to be exactly `local.user`, and they confuse the RSCP encryption key with the local user password). This PR makes the choice explicit.

## What changed

### Config flow (two-step)

1. **Step 1 – Authentication type**: A radio list to pick *Portal-User* (cloud) or *Local user (local.user)*.
2. **Step 2 – Credentials**:
   - For **Portal-User**: host, username (email), password, RSCP encryption key.
   - For **Local user**: host, password, RSCP encryption key. The username field is hidden and set automatically to `local.user`.

The chosen auth type is stored in the config entry data (`auth_type`) so it can be pre-selected later.

### Reauth flow

Same two-step pattern (auth type → credentials), with the previously used auth type pre-selected.

### Reconfigure flow (new)

A reconfigure step is now available from the device's three-dot menu. It lets users:

- Switch between Portal-User and Local user.
- Update host / username / password / RSCP key.

Fields are pre-filled with the current values.

### Labels & descriptions

`strings.json` and `translations/en.json` now include `data_description` hints for every field (what the host is, that the username is the portal email, where to find the RSCP encryption key on the device, etc.), so the form is self-explanatory.

### New constants in `const.py`

- `CONF_AUTH_TYPE = "auth_type"`
- `AUTH_TYPE_CLOUD = "cloud"`
- `AUTH_TYPE_LOCAL = "local"`
- `LOCAL_USERNAME = "local.user"`

## What did *not* change

- `e3dc_proxy.py` is untouched. `pye3dc` accepts any username/password pair; whether you log in as `local.user` or as an email is transparent to the proxy. `auth_type` is therefore UI metadata only.
- The SSDP discovery path (`async_step_ssdp_confirm`) is unchanged and remains portal-only.
- No new dependencies.

## Backwards compatibility

- Existing config entries continue to work. Entries without `auth_type` are treated as `cloud` (Portal-User) – which matches the previous behavior.
- No schema migration is required.

## Testing

Verified manually against a live E3DC S10E Pro:

- Fresh install via UI: Portal-User → works.
- Fresh install via UI: Local user (username auto-filled `local.user`) → works.
- Reauth: switch from Portal-User to Local user → works.
- Reconfigure from the three-dot menu: change credentials and switch auth type → works.
- Existing config entry from a previous version (without `auth_type` in data) → loads and works unchanged; reauth/reconfigure default to Portal-User.

## Notes for reviewers

- The two-step pattern keeps the schemas small and avoids a "ghost" username field for the local case, which I found cleaner than hiding it with a conditional schema.
- Translations: only `en` was updated in this PR. Other locales fall back to English; happy to add `de` too if you'd like it in this PR.
