### PR TITLE
feat: support pv-derated flag

### DIFF
--- a/custom_components/e3dc_rscp/binary_sensor.py
+++ b/custom_components/e3dc_rscp/binary_sensor.py
@@ -56,6 +56,13 @@ SENSOR_DESCRIPTIONS: Final[tuple[E3DCBinarySensorEntityDescription, ...]] = (
         off_icon="mdi:electric-switch",
     ),
     E3DCBinarySensorEntityDescription(
+        key="system-pv-derated",
+        translation_key="system-pv-derated",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        on_icon="mdi:solar-power-variant-outline",
+        off_icon="mdi:solar-power-variant",
+    ),
+    E3DCBinarySensorEntityDescription(
         key="sgready-active",
         translation_key="sgready-active",
         device_class=BinarySensorDeviceClass.RUNNING,

--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -337,6 +337,9 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug("Polling general status information")
         await self._load_and_process_poll()
 
+        _LOGGER.debug("Polling system status information")
+        await self._load_and_process_system_status()
+
         # TODO: Check if we need to replace this with a safe IPC sync
         if self._update_guard_powersettings is False:
             _LOGGER.debug("Poll power settings")
@@ -400,6 +403,24 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._mydata["pset-weatherregulationenabled"] = power_settings[
             "weatherRegulatedChargeEnabled"
         ]
+
+    async def _load_and_process_system_status(self) -> None:
+        """Load and process E3DC system status flags."""
+        try:
+            system_status: dict[str, Any] = await self.hass.async_add_executor_job(
+                self.proxy.get_system_status
+            )
+        except HomeAssistantError as ex:
+            _LOGGER.warning("Failed to load system status, not updating data: %s", ex)
+            return
+
+        if "pvDerated" not in system_status:
+            _LOGGER.debug(
+                "System status did not include pvDerated, keeping previous PV derated state"
+            )
+            return
+
+        self._mydata["system-pv-derated"] = bool(system_status["pvDerated"])
 
     async def _load_and_process_poll(self):
         """Load and process standard poll data."""

--- a/custom_components/e3dc_rscp/diagnostics.py
+++ b/custom_components/e3dc_rscp/diagnostics.py
@@ -58,6 +58,7 @@ class _DiagnosticsDumper:
         """Collect the individual dumped data successivley."""
         self.result: dict[str, Any] = {
             "current_data": self.coordinator.data,
+            "current_system_pv_derated": self.coordinator.data.get("system-pv-derated"),
             "get_system_info": self._query_data_for_dump(self.e3dc.get_system_info),
             "get_system_status": self._query_data_for_dump(self.e3dc.get_system_status),
             "get_powermeters": self._query_data_for_dump(self.e3dc.get_powermeters),

--- a/custom_components/e3dc_rscp/e3dc_proxy.py
+++ b/custom_components/e3dc_rscp/e3dc_proxy.py
@@ -173,6 +173,11 @@ class E3DCProxy:
         return self.e3dc.get_power_settings(keepAlive=True)
 
     @e3dc_call
+    def get_system_status(self) -> dict[str, Any]:
+        """Load E3DC system status flags."""
+        return self.e3dc.get_system_status(keepAlive=True)
+
+    @e3dc_call
     def get_powermeters(self) -> dict[str, Any]:
         """Load available powermeters from E3DC."""
         return self.e3dc.get_powermeters(keepAlive=True)

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -128,6 +128,9 @@
       "manual-charge-active": {
         "name": "Manual charge"
       },
+      "system-pv-derated": {
+        "name": "PV derated"
+      },
       "sgready-active": {
         "name": "SG Ready active"
       },

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -128,6 +128,9 @@
             "manual-charge-active": {
                 "name": "Manual charge"
             },
+            "system-pv-derated": {
+                "name": "PV derated"
+            },
             "sgready-active": {
                 "name": "SG Ready active"
             },


### PR DESCRIPTION
signals whether the PV is in a throttled state. Tested and works for my S10x.

Background: I'm using EVCC, and that (currently) relies on distributing excess power. In a zero feed-in scenario, there mostly is now excess power to distribute.
By making the throttling detectable, I can use Home Assistant automation to force-generate load on my wallbox and thereby increase the power generated by the PV.

Apologies if the code is not up to standards, I'm a java/kotlin dev :)
Please let me know if there is anything to be improved.