### PR TITLE
Revert manual charge API workaround from #118

### DIFF
--- a/custom_components/e3dc_rscp/e3dc_proxy.py
+++ b/custom_components/e3dc_rscp/e3dc_proxy.py
@@ -141,37 +141,29 @@ class E3DCProxy:
     @e3dc_call
     def get_manual_charge(self) -> dict[str, Any]:
         """Poll manual charging state."""
-        try:
-            data = self.e3dc.sendRequest(
-                (RscpTag.EMS_REQ_GET_MANUAL_CHARGE, RscpType.NoneType, None),
-                keepAlive=True,
-            )
+        data = self.e3dc.sendRequest(
+            (RscpTag.EMS_REQ_GET_MANUAL_CHARGE, RscpType.NoneType, None),
+            keepAlive=True,
+        )
 
-            result: dict[str, Any] = {}
-            result["active"] = rscpFindTag(data, RscpTag.EMS_MANUAL_CHARGE_ACTIVE)[2]
+        result: dict[str, Any] = {}
+        result["active"] = rscpFindTag(data, RscpTag.EMS_MANUAL_CHARGE_ACTIVE)[2]
 
-            # These seem to be kAh per individual cell, so this is considered very strange.
-            # To get this working for a start, we assume 3,65 V per cell, taking my own unit
-            # as a base, but this obviously will need some real work to base this on
-            # current voltages.
-            # Round to Watts, this should prevent negative values in the magnitude of 10^-6,
-            # which are probably floating point errors.
-            tmp = rscpFindTag(data, RscpTag.EMS_MANUAL_CHARGE_ENERGY_COUNTER)[2]
-            powerfactor = 3.65
-            result["energy"] = round(tmp * powerfactor, 3)
+        # These seem to be kAh per individual cell, so this is considered very strange.
+        # To get this working for a start, we assume 3,65 V per cell, taking my own unit
+        # as a base, but this obviously will need some real work to base this on
+        # current voltages.
+        # Round to Watts, this should prevent negative values in the magnitude of 10^-6,
+        # which are probably floating point errors.
+        tmp = rscpFindTag(data, RscpTag.EMS_MANUAL_CHARGE_ENERGY_COUNTER)[2]
+        powerfactor = 3.65
+        result["energy"] = round(tmp * powerfactor, 3)
 
-            # The timestamp seem to correctly show the UTC Date when manual charging started
-            # Not yet enabled, just for reference.
-            # self._mydata["manual-charge-start"] = rscpFindTag(
-            #     request_data, "EMS_MANUAL_CHARGE_LASTSTART"
-            # )[2]
-        except SendError:
-            _LOGGER.debug(
-                "Failed to query manual charging data, might be related to a recent E3DC API change, ignoring the error, reverting to empty defaults."
-            )
-            result: dict[str, Any] = {}
-            result["active"] = False
-            result["energy"] = 0
+        # The timestamp seem to correctly show the UTC Date when manual charging started
+        # Not yet enabled, just for reference.
+        # self._mydata["manual-charge-start"] = rscpFindTag(
+        #     request_data, "EMS_MANUAL_CHARGE_LASTSTART"
+        # )[2]
 
         return result
 


### PR DESCRIPTION
## Summary

Removes the emergency `SendError` catch in `get_manual_charge()` that was introduced in #118 as a workaround for a firmware change in `P10_2023_06`.

## Why revert now?

The `@e3dc_call` decorator already handles `SendError` uniformly across all proxy methods — it converts it to `HomeAssistantError`, which surfaces as an unavailable entity and triggers HA's automatic retry/backoff. The workaround bypassed this by silently returning `{"active": False, "energy": 0}`, hiding real errors from the user.

The upstram API issue that triggered the workaround has been resolved upstream. Keeping the catch violates the proxy pattern established in the codebase and masks legitimate failures.

## Change

- Remove `try/except SendError` block from `get_manual_charge()`
- Restore clean, flat code structure consistent with all other proxy methods
- Error handling is now delegated to `@e3dc_call` as intended

Closes/reverts workaround for #114.