### PR TITLE
Address Copilot review comments from PR #340 (Wallbox EMS Settings)

### DIFF
--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -354,9 +354,11 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._load_and_process_powermeters_data()
 
         if self._update_guard_wallboxsettings is False:
-            if len(self.wallboxes) > 0:
+            if self.wallboxes:
                 _LOGGER.debug("Polling wallbox")
-            await self._load_and_process_wallbox_data()
+                await self._load_and_process_wallbox_data()
+            else:
+                _LOGGER.debug("Skipping wallbox poll, no wallboxes configured")
         else:
             _LOGGER.debug("Not polling wallbox, they are updating right now")
 
@@ -652,7 +654,7 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug("Updated powersaving to %s", enabled)
         return True
 
-    async def async_set_battery_before_car_mode(self, enabled: bool) -> None:
+    async def async_set_battery_before_car_mode(self, enabled: bool) -> bool:
         """Enable or disable battery charge before car mode."""
         _LOGGER.debug("Updating battery before car mode to %s", enabled)
 
@@ -666,8 +668,9 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._update_guard_wallboxsettings = False
 
         _LOGGER.debug("Successfully updated battery before car mode to %s", enabled)
+        return True
 
-    async def async_set_battery_to_car_mode(self, enabled: bool) -> None:
+    async def async_set_battery_to_car_mode(self, enabled: bool) -> bool:
         """Enable or disable battery charge car with battery mode."""
         _LOGGER.debug("Updating battery to car mode to %s", enabled)
 
@@ -681,8 +684,9 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._update_guard_wallboxsettings = False
 
         _LOGGER.debug("Successfully updated battery to car mode to %s", enabled)
+        return True
 
-    async def async_set_battery_wallbox_discharge_limit(self, limit: int) -> None:
+    async def async_set_battery_wallbox_discharge_limit(self, limit: int) -> bool:
         """Set the battery wallbox discharge limit (SoC limit)."""
         _LOGGER.debug("Updating battery wallbox discharge limit to %s%%", limit)
 
@@ -698,8 +702,9 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug(
             "Successfully updated battery wallbox discharge limit to %s%%", limit
         )
+        return True
 
-    async def async_set_wallbox_enforce_power_assignment(self, enforce: bool) -> None:
+    async def async_set_wallbox_enforce_power_assignment(self, enforce: bool) -> bool:
         """Enable or disable wallbox enforce power assignment mode."""
         _LOGGER.debug("Updating wallbox enforce power assignment to %s", enforce)
 
@@ -715,6 +720,7 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug(
             "Successfully updated wallbox enforce power assignment to %s", enforce
         )
+        return True
 
     async def async_set_wallbox_sun_mode(
         self, enabled: bool, wallbox_index: int

--- a/custom_components/e3dc_rscp/e3dc_proxy.py
+++ b/custom_components/e3dc_rscp/e3dc_proxy.py
@@ -181,23 +181,23 @@ class E3DCProxy:
     def get_wallbox_ems_settings(self) -> dict[str, Any]:
         """Load wallbox EMS settings."""
         beforeCarMode: int = self.e3dc.sendRequestTag(
-            RscpTag.EMS_REQ_BATTERY_BEFORE_CAR_MODE
+            RscpTag.EMS_REQ_BATTERY_BEFORE_CAR_MODE, keepAlive=True
         )
         batToCarMode: int = self.e3dc.sendRequestTag(
-            RscpTag.EMS_REQ_BATTERY_TO_CAR_MODE
+            RscpTag.EMS_REQ_BATTERY_TO_CAR_MODE, keepAlive=True
         )
         batWBDischargeLimit: int = self.e3dc.sendRequestTag(
-            RscpTag.EMS_REQ_GET_WB_DISCHARGE_BAT_UNTIL
+            RscpTag.EMS_REQ_GET_WB_DISCHARGE_BAT_UNTIL, keepAlive=True
         )
-        wbEnforcePowerAssignement: bool = self.e3dc.sendRequestTag(
-            RscpTag.EMS_REQ_GET_WALLBOX_ENFORCE_POWER_ASSIGNMENT
+        wbEnforcePowerAssignment: bool = self.e3dc.sendRequestTag(
+            RscpTag.EMS_REQ_GET_WALLBOX_ENFORCE_POWER_ASSIGNMENT, keepAlive=True
         )
 
         result: dict[str, Any] = {}
         result["battery-before-car-mode"] = False if beforeCarMode == 0 else True
         result["battery-to-car-mode"] = False if batToCarMode == 0 else True
         result["battery-wallbox-discharge-limit"] = batWBDischargeLimit
-        result["wallbox-enforce-power-assignment"] = wbEnforcePowerAssignement
+        result["wallbox-enforce-power-assignment"] = wbEnforcePowerAssignment
         return result
 
     @e3dc_call
@@ -530,8 +530,8 @@ class E3DCProxy:
         return False if result[2] == 0 else True
 
     @e3dc_call
-    def set_battery_wallbox_discharge_limit(self, limit: int) -> None:
-        """Set the battery wallbox discharge limit."""
+    def set_battery_wallbox_discharge_limit(self, limit: int) -> int:
+        """Set the battery wallbox discharge limit, returns the value E3DC reports back."""
         # We don't get a sensible result here, E3DC returns the value
         # EMS_SET_BATTERY_BEFORE_CAR_MODE instead, which does not help us.
         # Thus, we need to query it afterwards.
@@ -540,7 +540,9 @@ class E3DCProxy:
             (RscpTag.EMS_REQ_SET_WB_DISCHARGE_BAT_UNTIL, RscpType.Uint32, limit),
             keepAlive=True,
         )
-        return self.e3dc.sendRequestTag(RscpTag.EMS_REQ_GET_WB_DISCHARGE_BAT_UNTIL)
+        return self.e3dc.sendRequestTag(
+            RscpTag.EMS_REQ_GET_WB_DISCHARGE_BAT_UNTIL, keepAlive=True
+        )
 
     @e3dc_call
     def set_wallbox_enforce_power_assignment(self, enforce: bool) -> bool:

--- a/custom_components/e3dc_rscp/number.py
+++ b/custom_components/e3dc_rscp/number.py
@@ -56,8 +56,9 @@ async def async_setup_entry(
             entity_category=EntityCategory.CONFIG,
             native_unit_of_measurement="%",
             enabling_depends_on_wallbox=True,
-            async_set_native_value_action=lambda coordinator,
-            value: coordinator.async_set_battery_wallbox_discharge_limit(int(value)),
+            async_set_native_value_action=lambda coordinator, value: (
+                coordinator.async_set_battery_wallbox_discharge_limit(int(value))
+            ),
         ),
         # Wallbox-specific numbers are still added per wallbox below
     )
@@ -87,10 +88,8 @@ async def async_setup_entry(
             device_class=NumberDeviceClass.CURRENT,
             entity_category=EntityCategory.CONFIG,
             native_unit_of_measurement="A",
-            async_set_native_value_action=lambda coordinator,
-            value,
-            index=wallbox["index"]: coordinator.async_set_wallbox_max_charge_current(
-                int(value), index
+            async_set_native_value_action=lambda coordinator, value, index=wallbox["index"]: (
+                coordinator.async_set_wallbox_max_charge_current(int(value), index)
             ),
         )
         entities.append(

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -487,7 +487,7 @@
         "name": "Schuko"
       },
       "battery-before-car-mode": {
-        "name": "Wallbox charging priorization",
+        "name": "Wallbox charging prioritization",
         "state": {
           "on": "Battery First",
           "off": "Wallbox First"
@@ -501,10 +501,10 @@
         }
       },
       "wallbox-enforce-power-assignment": {
-        "name": "Enforce settings when discharging battery by wallbox",
+        "name": "Enforce power assignment when discharging battery by wallbox",
         "state": {
-          "on": "Blocked",
-          "off": "Allow in mixed mode and during hold and timers"
+          "on": "Disallowed",
+          "off": "Allowed in mixed mode and during hold and timers"
         }
       }
     },

--- a/custom_components/e3dc_rscp/switch.py
+++ b/custom_components/e3dc_rscp/switch.py
@@ -61,11 +61,11 @@ SWITCHES: Final[tuple[E3DCSwitchEntityDescription, ...]] = (
         off_icon="mdi:weather-sunny-off",
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
-        async_turn_on_action=lambda coordinator: coordinator.async_set_weather_regulated_charge(
-            True
+        async_turn_on_action=lambda coordinator: (
+            coordinator.async_set_weather_regulated_charge(True)
         ),
-        async_turn_off_action=lambda coordinator: coordinator.async_set_weather_regulated_charge(
-            False
+        async_turn_off_action=lambda coordinator: (
+            coordinator.async_set_weather_regulated_charge(False)
         ),
     ),
     # EMS WALLBOX SWITCHES
@@ -77,11 +77,11 @@ SWITCHES: Final[tuple[E3DCSwitchEntityDescription, ...]] = (
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
         enabling_depends_on_wallbox=True,
-        async_turn_on_action=lambda coordinator: coordinator.async_set_battery_before_car_mode(
-            True
+        async_turn_on_action=lambda coordinator: (
+            coordinator.async_set_battery_before_car_mode(True)
         ),
-        async_turn_off_action=lambda coordinator: coordinator.async_set_battery_before_car_mode(
-            False
+        async_turn_off_action=lambda coordinator: (
+            coordinator.async_set_battery_before_car_mode(False)
         ),
     ),
     E3DCSwitchEntityDescription(
@@ -92,14 +92,14 @@ SWITCHES: Final[tuple[E3DCSwitchEntityDescription, ...]] = (
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
         enabling_depends_on_wallbox=True,
-        available_fn=lambda coordinator: not coordinator.data.get(
-            "battery-before-car-mode"
+        available_fn=lambda coordinator: (
+            not coordinator.data.get("battery-before-car-mode")
         ),
-        async_turn_on_action=lambda coordinator: coordinator.async_set_battery_to_car_mode(
-            True
+        async_turn_on_action=lambda coordinator: (
+            coordinator.async_set_battery_to_car_mode(True)
         ),
-        async_turn_off_action=lambda coordinator: coordinator.async_set_battery_to_car_mode(
-            False
+        async_turn_off_action=lambda coordinator: (
+            coordinator.async_set_battery_to_car_mode(False)
         ),
     ),
     E3DCSwitchEntityDescription(
@@ -110,11 +110,11 @@ SWITCHES: Final[tuple[E3DCSwitchEntityDescription, ...]] = (
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
         enabling_depends_on_wallbox=True,
-        async_turn_on_action=lambda coordinator: coordinator.async_set_wallbox_enforce_power_assignment(
-            True
+        async_turn_on_action=lambda coordinator: (
+            coordinator.async_set_wallbox_enforce_power_assignment(True)
         ),
-        async_turn_off_action=lambda coordinator: coordinator.async_set_wallbox_enforce_power_assignment(
-            False
+        async_turn_off_action=lambda coordinator: (
+            coordinator.async_set_wallbox_enforce_power_assignment(False)
         ),
     ),
 )
@@ -152,11 +152,11 @@ async def async_setup_entry(
             on_icon="mdi:weather-sunny",
             off_icon="mdi:weather-sunny-off",
             device_class=SwitchDeviceClass.SWITCH,
-            async_turn_on_action=lambda coordinator,
-            index=wallbox["index"]: coordinator.async_set_wallbox_sun_mode(True, index),
-            async_turn_off_action=lambda coordinator,
-            index=wallbox["index"]: coordinator.async_set_wallbox_sun_mode(
-                False, index
+            async_turn_on_action=lambda coordinator, index=wallbox["index"]: (
+                coordinator.async_set_wallbox_sun_mode(True, index)
+            ),
+            async_turn_off_action=lambda coordinator, index=wallbox["index"]: (
+                coordinator.async_set_wallbox_sun_mode(False, index)
             ),
         )
         entities.append(
@@ -175,10 +175,12 @@ async def async_setup_entry(
             on_icon="mdi:power-plug",
             off_icon="mdi:power-plug-off",
             device_class=SwitchDeviceClass.OUTLET,
-            async_turn_on_action=lambda coordinator,
-            index=wallbox["index"]: coordinator.async_set_wallbox_schuko(True, index),
-            async_turn_off_action=lambda coordinator,
-            index=wallbox["index"]: coordinator.async_set_wallbox_schuko(False, index),
+            async_turn_on_action=lambda coordinator, index=wallbox["index"]: (
+                coordinator.async_set_wallbox_schuko(True, index)
+            ),
+            async_turn_off_action=lambda coordinator, index=wallbox["index"]: (
+                coordinator.async_set_wallbox_schuko(False, index)
+            ),
             entity_registry_enabled_default=False,  # Disabled per default as only Wallbox multi connect I provides this feature
         )
         entities.append(
@@ -223,9 +225,11 @@ class E3DCSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if self.entity_description.available_fn is not None:
-            return self.entity_description.available_fn(self.coordinator)
-        return True
+        return super().available and (
+            self.entity_description.available_fn(self.coordinator)
+            if self.entity_description.available_fn is not None
+            else True
+        )
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -562,24 +562,24 @@
                 "name": "Schuko"
             },
             "battery-before-car-mode": {
-                "name": "Wallbox charging priorization",
+                "name": "Wallbox charging prioritization",
                 "state": {
-                    "on": "Battery first",
-                    "off": "Wallbox first"
+                    "on": "Battery First",
+                    "off": "Wallbox First"
                 }
             },
             "battery-to-car-mode": {
                 "name": "Battery discharge by wallbox in sun mode",
                 "state": {
                     "on": "Allowed",
-                    "off": "Disallowed"
+                    "off": "Blocked"
                 }
             },
             "wallbox-enforce-power-assignment": {
-                "name": "Battery discharge by wallbox in special modes",
+                "name": "Enforce power assignment when discharging battery by wallbox",
                 "state": {
-                    "on": "Suspended",
-                    "off": "Allow in mix mode, during hold time and time function"
+                    "on": "Disallowed",
+                    "off": "Allowed in mixed mode and during hold and timers"
                 }
             }
         },


### PR DESCRIPTION
- switch.py: preserve CoordinatorEntity.available in E3DCSwitch.available instead of unconditionally returning True when available_fn is unset
- e3dc_proxy.py: add keepAlive=True to all sendRequestTag calls in get_wallbox_ems_settings and in set_battery_wallbox_discharge_limit's read-back request, for consistency with other proxy methods
- e3dc_proxy.py: fix set_battery_wallbox_discharge_limit return type annotation (None -> int) to match actual returned value
- e3dc_proxy.py: rename typo'd variable wbEnforcePowerAssignement ->
  wbEnforcePowerAssignment
- coordinator.py: gate _load_and_process_wallbox_data() behind "if self.wallboxes" so wallbox-only EMS tags aren't polled when no wallbox is configured
- coordinator.py: async_set_battery_before_car_mode, async_set_battery_to_car_mode, async_set_battery_wallbox_discharge_limit and async_set_wallbox_enforce_power_assignment now return bool to match the Coroutine[..., bool] action typing used in switch.py/number.py
- strings.json / translations/en.json: fix "priorization" ->
  "prioritization" typo and align battery-to-car-mode / wallbox-enforce-power-assignment names and state text so both files are identical