### PR TITLE
Fix robustness issues around wallbox EMS settings and SG Ready enum (4.0.0-beta.1)

### DIFF
--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -548,22 +548,34 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             4: "start_up",
         }
         raw_state = request_data["sgready-state"]
-        self._mydata["sgready-state"] = sgready_state_map.get(raw_state, str(raw_state))
+        mapped_state = sgready_state_map.get(raw_state)
+        if mapped_state is None:
+            # The sensor is an ENUM sensor, values outside of its options list
+            # would be rejected by HA, so keep the previous state instead.
+            _LOGGER.warning(
+                "Unknown SG Ready state %s, keeping previous state", raw_state
+            )
+        else:
+            self._mydata["sgready-state"] = mapped_state
         self._mydata["sgready-numeric-state"] = request_data["sgready-numeric-state"]
         self._mydata["sgready-active"] = bool(request_data["sgready-active"])
         self._sgready_available = bool(request_data["sgready-active"])
 
-    async def _load_and_process_wallbox_data(self) -> None:
-        """Load and process wallbox data to existing data."""
+    async def _load_and_process_wallbox_ems_settings(self) -> None:
+        """Load and process EMS-level wallbox settings.
 
-        # Load EMS general settings:
-
+        These are independent of the per-wallbox readings, so a failure here
+        (e.g. firmware without support for these RSCP tags) must not prevent
+        the regular wallbox polling.
+        """
         try:
             ems_wb_state: dict[str, Any] = await self.hass.async_add_executor_job(
                 self.proxy.get_wallbox_ems_settings
             )
         except HomeAssistantError as ex:
-            _LOGGER.warning("Failed to load EMS wallbox settings: %s", ex)
+            _LOGGER.warning(
+                "Failed to load EMS wallbox settings, not updating them: %s", ex
+            )
             return
 
         self._mydata["battery-before-car-mode"] = ems_wb_state[
@@ -577,14 +589,22 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "wallbox-enforce-power-assignment"
         ]
 
+    async def _load_and_process_wallbox_data(self) -> None:
+        """Load and process wallbox data to existing data."""
+        await self._load_and_process_wallbox_ems_settings()
+
         for wallbox in self.wallboxes:
             try:
                 request_data: dict[str, Any] = await self.hass.async_add_executor_job(
                     self.proxy.get_wallbox_data, wallbox["index"]
                 )
             except HomeAssistantError as ex:
-                _LOGGER.warning("Failed to load wallboxes, not updating data: %s", ex)
-                return
+                _LOGGER.warning(
+                    "Failed to load wallbox %s, not updating its data: %s",
+                    wallbox["index"],
+                    ex,
+                )
+                continue
 
             for key, value in request_data.items():
                 formatted_key = re.sub(

--- a/custom_components/e3dc_rscp/e3dc_proxy.py
+++ b/custom_components/e3dc_rscp/e3dc_proxy.py
@@ -198,11 +198,18 @@ class E3DCProxy:
             RscpTag.EMS_REQ_GET_WALLBOX_ENFORCE_POWER_ASSIGNMENT, keepAlive=True
         )
 
+        # sendRequestTag may return None if the response could not be parsed,
+        # treat this as an error instead of silently reporting wrong states.
+        if beforeCarMode is None or batToCarMode is None:
+            raise HomeAssistantError(
+                "Failed to load wallbox EMS settings, got no data from E3DC"
+            )
+
         result: dict[str, Any] = {}
-        result["battery-before-car-mode"] = False if beforeCarMode == 0 else True
-        result["battery-to-car-mode"] = False if batToCarMode == 0 else True
+        result["battery-before-car-mode"] = beforeCarMode != 0
+        result["battery-to-car-mode"] = batToCarMode != 0
         result["battery-wallbox-discharge-limit"] = batWBDischargeLimit
-        result["wallbox-enforce-power-assignment"] = wbEnforcePowerAssignment
+        result["wallbox-enforce-power-assignment"] = bool(wbEnforcePowerAssignment)
         return result
 
     @e3dc_call


### PR DESCRIPTION
## Summary

While reviewing the 4.0.0-beta.1 code (see discussion #369), I found a few robustness issues in the new wallbox EMS settings code from #361 and the SG Ready enum conversion from #317. All of them are edge cases, none of them is a functional problem on firmware that fully supports the new RSCP tags.

### 1. EMS settings failure skipped all regular wallbox polling

`_load_and_process_wallbox_data()` fetched the new EMS-level settings first and did an early `return` on failure. If `get_wallbox_ems_settings()` fails (e.g. firmware that does not support `EMS_REQ_BATTERY_BEFORE_CAR_MODE` / `EMS_REQ_GET_WALLBOX_ENFORCE_POWER_ASSIGNMENT`), the regular per-wallbox readings (charging state, SoC, plug state, ...) were skipped for that cycle as well, even though they are independent requests that used to work fine in 3.11.x.

The EMS settings are now loaded in their own method `_load_and_process_wallbox_ems_settings()`; a failure there only logs a warning and no longer prevents the per-wallbox polling.

### 2. A single failing wallbox aborted polling of the remaining ones

The per-wallbox loop used `return` in its exception handler, so a failure on wallbox 0 also stopped updates for wallbox 1. Changed to `continue` (with the wallbox index included in the warning).

### 3. SG Ready enum sensor could report a value outside its options

The coordinator mapped unknown raw states to `str(raw_state)` as a fallback. Since #317 declares the sensor as `SensorDeviceClass.ENUM` with a fixed options list, HA rejects any value outside `["locked", "normal", "released", "start_up"]` and logs an error. Unknown raw values now keep the previous state and log a warning instead.

### 4. `None` responses were interpreted as `True`

In `get_wallbox_ems_settings()`, `False if beforeCarMode == 0 else True` evaluates to `True` when `sendRequestTag()` returns `None`. A `None` response for either mode flag now raises a `HomeAssistantError` (handled by the coordinator like any other failure) instead of silently reporting a wrong switch state. Also simplified the conversions to `!= 0` / `bool(...)`.

## Not touched

The return value interpretation in `set_battery_before_car_mode()` / `set_battery_to_car_mode()` (the `result[2] == 255` / echo handling) looks fragile too, but since the code comments already document that the E3DC firmware returns inconsistent echoes for these tags, I did not want to change behavior there without hardware coverage across firmware versions. Happy to discuss.

## Testing

- `ruff check` and `ruff format --check` pass with the repo config
- **Please note:** these changes are based on code review only. My unit has neither SG Ready nor an E3DC wallbox, so I cannot test the affected code paths on real hardware myself. Testing by users with wallbox / SG Ready setups (e.g. from the beta discussion #369) would be much appreciated.