### PR TITLE
Add saved error history sensor (EH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ code.
   - [Set maximum wallbox charging current](#set-maximum-wallbox-charging-current)
   - [Set power mode](#set-power-mode)
 - [Optional Battery Pack and Module Devices](#optional-battery-pack-and-module-devices)
+- [Saved error history](#saved-error-history)
 - [Upstream source](#upstream-source)
 
 ## Disclaimer
@@ -282,6 +283,70 @@ Notes:
 - **Battery Module State of Health (SoH)**: The integration always calculates SoH from capacities using the formula `(full charge capacity / design capacity) × 100`. Some E3DC systems also report their own SoH value, which may differ from the calculated value. If your E3DC system provides device-reported SoH values, an additional diagnostic sensor "State of health (device-reported)" will be created (disabled by default) for comparison and debugging purposes. This sensor is only created for battery modules where the E3DC system actually provides a SoH value. The calculated SoH is used as the primary sensor for consistency and accuracy across all E3DC systems.
 
 - due to the various possible configurations of batteries (different E3DC devices, different amount of battery packs and modules, farming setups, etc.), not all scenarios couldn't be tested. In case your setup is not represented correctly, open an issue including a diagnostic dump.
+
+## Saved error history
+
+The integration exposes a diagnostic sensor **Saved error history**
+(`system-saved-errors`) that reads the E3DC EH (error history) block via
+`EH_REQ_GET_SAVED_ERRORS`.
+
+| | |
+|---|---|
+| **State** | Number of stored history entries |
+| **Update interval** | Every 5 minutes |
+| **Default** | Disabled — enable it under the E3DC device entities |
+
+### Attributes
+
+| Attribute | Description |
+|---|---|
+| `latest_message` | Latest error text (hex prefixes like `0x40000000:` stripped) |
+| `latest_time` | Local timestamp of the latest entry |
+| `latest_source` | Source code of the latest entry (e.g. `E12`) |
+| `messages` | List of cleaned message strings, newest first |
+| `summary` | Markdown-ready multi-line summary, newest first |
+| `items` | Raw list (`msg`, `code`, `time`, `source`, `type`, `cleared`) |
+
+Active diagnostic issues (DIAG) are **not** exposed: E3DC returns
+`RSCP_ERR_ACCESS_DENIED` for typical user levels.
+
+### Lovelace example (Markdown card)
+
+Replace the entity id with your sensor
+(e.g. `sensor.<device>_saved_error_history`):
+
+```yaml
+type: markdown
+title: E3DC error history
+content: |
+  {% set e = 'sensor.YOUR_DEVICE_saved_error_history' %}
+  **{{ states(e) }} entries** · latest {{ state_attr(e, 'latest_time') }}
+
+  {{ state_attr(e, 'summary') }}
+```
+
+A compact header card:
+
+```yaml
+type: entities
+title: E3DC error history
+entities:
+  - entity: sensor.YOUR_DEVICE_saved_error_history
+    name: Entries
+    secondary_info: last-updated
+  - type: attribute
+    entity: sensor.YOUR_DEVICE_saved_error_history
+    attribute: latest_message
+    name: Latest error
+  - type: attribute
+    entity: sensor.YOUR_DEVICE_saved_error_history
+    attribute: latest_time
+    name: Time
+  - type: attribute
+    entity: sensor.YOUR_DEVICE_saved_error_history
+    attribute: latest_source
+    name: Source
+```
 
 ## Upstream source
 

--- a/custom_components/e3dc_rscp/__init__.py
+++ b/custom_components/e3dc_rscp/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .const import CONF_FARMCONTROLLER, DOMAIN, PLATFORMS
+from .rscp_frame_compat import patch_rscp_frame_reassembly
 
 from homeassistant.const import (
     CONF_API_VERSION,
@@ -27,6 +28,13 @@ from homeassistant.const import (
 from .coordinator import E3DCCoordinator
 from .services import async_setup_services
 from e3dc._e3dc_rscp_local import DEFAULT_PORT as RSCP_PORT
+
+# pye3dc's local RSCP transport assumes a single socket.recv() call
+# always returns a complete frame, which fails for larger responses
+# (e.g. an extensive EH_REQ_GET_SAVED_ERRORS history). Patch it to
+# reassemble frames split across multiple reads. Safe to drop once
+# fixed upstream in python-e3dc.
+patch_rscp_frame_reassembly()
 
 
 async def async_migrate_entry(hass, config_entry: ConfigEntry):

--- a/custom_components/e3dc_rscp/coordinator.py
+++ b/custom_components/e3dc_rscp/coordinator.py
@@ -42,6 +42,7 @@ from .battery_manager import E3DCBatteryManager, E3DCBattery, E3DCBatteryPack
 
 _LOGGER = logging.getLogger(__name__)
 _STAT_REFRESH_INTERVAL = 60
+_EH_REFRESH_INTERVAL = 300
 
 # Maps the system status flags as delivered by get_system_status() onto our
 # coordinator data keys. All of them are booleans describing the current state of
@@ -97,6 +98,7 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._sgready_available: bool = False
         self._timezone_offset: int = 0
         self._next_stat_update: float = 0
+        self._next_eh_update: float = 0
         self._isFarmController: bool = config_entry.data.get("farmcontroller", False)
 
         # Initialize battery manager
@@ -395,7 +397,7 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("Polling battery data")
             await self.battery_manager.async_load_and_process_battery_data()
 
-        # Only poll power statstics once per minute. E3DC updates it only once per 15
+        # Only poll power statistics once per minute. E3DC updates it only once per 15
         # minutes anyway, this should be a good compromise to get the metrics shortly
         # before the end of the day.
         if self._next_stat_update < time():
@@ -406,6 +408,16 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # end of day reading of the metric.
         else:
             _LOGGER.debug("Skipping power metrics poll.")
+
+        # Saved error history changes rarely; poll at most every five minutes.
+        # DIAG current issues are intentionally not polled: E3DC returns
+        # RSCP_ERR_ACCESS_DENIED for DIAG_REQ_CURRENT_ISSUES at normal user level.
+        if self._next_eh_update < time():
+            _LOGGER.debug("Polling saved error history")
+            await self._load_and_process_saved_errors()
+            self._next_eh_update = time() + _EH_REFRESH_INTERVAL
+        else:
+            _LOGGER.debug("Skipping saved error history poll.")
 
         return self._mydata
 
@@ -517,6 +529,23 @@ class E3DCCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._mydata["manual-charge-active"] = request_data["active"]
         self._mydata["manual-charge-energy"] = request_data["energy"]
+
+    async def _load_and_process_saved_errors(self) -> None:
+        """Load and process saved error history."""
+        try:
+            request_data: dict[str, Any] = await self.hass.async_add_executor_job(
+                self.proxy.get_saved_errors
+            )
+        except HomeAssistantError as ex:
+            _LOGGER.warning(
+                "Failed to load saved error history, not updating data: %s",
+                ex,
+                exc_info=True,
+            )
+            return
+
+        self._mydata["system-saved-errors"] = request_data["count"]
+        self._mydata["system-saved-errors-list"] = request_data["errors"]
 
     async def _load_and_process_powermeters_data(self) -> None:
         """Load and process additional sources to existing data."""

--- a/custom_components/e3dc_rscp/diagnostics.py
+++ b/custom_components/e3dc_rscp/diagnostics.py
@@ -79,6 +79,7 @@ class _DiagnosticsDumper:
             "get_wallbox_ems_settings": self._query_data_for_dump(
                 self.proxy.get_wallbox_ems_settings
             ),
+            "get_saved_errors": self._query_data_for_dump(self.proxy.get_saved_errors),
             "is_farm_controller": self.coordinator.is_farm_controller(),
             "EMS_REQ_GET_MANUAL_CHARGE": self._query_data_for_dump(
                 lambda: self.e3dc.sendRequestTag(

--- a/custom_components/e3dc_rscp/e3dc_proxy.py
+++ b/custom_components/e3dc_rscp/e3dc_proxy.py
@@ -24,6 +24,46 @@ _LOGGER = logging.getLogger(__name__)
 FARM_PARAM_SERIALNO = "FARM_PARAM_SERIALNO"
 
 
+def _safe_tag_value(msg: Any, tag: RscpTag) -> Any:
+    """Return the value of a nested RSCP tag, or None if missing."""
+    found = rscpFindTag(msg, tag)
+    if found is None:
+        return None
+    return found[2]
+
+
+def _iter_tagged_children(msg: Any, tag: RscpTag):
+    """Yield direct child messages matching ``tag`` from a container."""
+    if msg is None or not isinstance(msg[2], list):
+        return
+    tag_name = tag.name
+    for child in msg[2]:
+        if child[0] == tag_name:
+            yield child
+
+
+def _normalize_rscp_value(value: Any) -> Any:
+    """Make RSCP values JSON-/HA-attribute friendly."""
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except (TypeError, ValueError):
+            return str(value)
+    return value
+
+
+def _rscp_error_message(data: Any) -> str | None:
+    """Return RSCP error name if ``data`` is an Error response, else None."""
+    if not isinstance(data, tuple) or len(data) < 3:
+        return None
+    type_name = data[1]
+    if type_name in ("Error", RscpType.Error, "Error8", "Error32"):
+        return str(data[2])
+    if isinstance(type_name, str) and type_name.lower().startswith("error"):
+        return str(data[2])
+    return None
+
+
 class ThreadSafeE3DC(E3DC):
     """Thread-safe version of E3DC."""
 
@@ -176,6 +216,56 @@ class E3DCProxy:
     def get_system_status(self) -> dict[str, Any]:
         """Load E3DC system status flags."""
         return self.e3dc.get_system_status(keepAlive=True)
+
+    @e3dc_call
+    def get_saved_errors(self) -> dict[str, Any]:
+        """Load saved error history from E3DC (EH block).
+
+        Returns:
+            Dict with ``count`` and ``errors`` list. Each error contains
+            ``msg``, ``code``, ``time``, ``source``, ``type`` and ``cleared``.
+
+        """
+        data = self.e3dc.sendRequest(
+            (RscpTag.EH_REQ_GET_SAVED_ERRORS, RscpType.NoneType, None),
+            retries=1,
+            keepAlive=True,
+        )
+
+        if error := _rscp_error_message(data):
+            _LOGGER.warning(
+                "EH_REQ_GET_SAVED_ERRORS rejected by E3DC: %s "
+                "(user level may be insufficient)",
+                error,
+            )
+            return {"count": 0, "errors": [], "error": error}
+
+        errors: list[dict[str, Any]] = []
+        for row in _iter_tagged_children(data, RscpTag.EH_PARAM_ROW):
+            errors.append(
+                {
+                    "msg": _normalize_rscp_value(
+                        _safe_tag_value(row, RscpTag.EH_PARAM_ROW_MSG)
+                    ),
+                    "code": _normalize_rscp_value(
+                        _safe_tag_value(row, RscpTag.EH_PARAM_ROW_CODE)
+                    ),
+                    "time": _normalize_rscp_value(
+                        _safe_tag_value(row, RscpTag.EH_PARAM_ROW_TIME)
+                    ),
+                    "source": _normalize_rscp_value(
+                        _safe_tag_value(row, RscpTag.EH_PARAM_ROW_ERR_SRC)
+                    ),
+                    "type": _normalize_rscp_value(
+                        _safe_tag_value(row, RscpTag.EH_PARAM_ROW_TYPE)
+                    ),
+                    "cleared": _normalize_rscp_value(
+                        _safe_tag_value(row, RscpTag.EH_PARAM_ROW_CLEARED)
+                    ),
+                }
+            )
+
+        return {"count": len(errors), "errors": errors}
 
     @e3dc_call
     def get_powermeters(self) -> dict[str, Any]:

--- a/custom_components/e3dc_rscp/rscp_frame_compat.py
+++ b/custom_components/e3dc_rscp/rscp_frame_compat.py
@@ -1,0 +1,117 @@
+"""Compatibility patch for pye3dc's local RSCP frame reassembly.
+
+``E3DC_RSCP_local._receive()`` in python-e3dc performs a single
+``socket.recv(BUFFER_SIZE)`` call and assumes the entire encrypted RSCP
+frame arrived in that one read. TCP gives no such guarantee: larger
+responses (e.g. ``EH_REQ_GET_SAVED_ERRORS`` on units with an extensive
+saved-error history) can be split across multiple reads, which makes
+``rscpFrameDecode`` fail with::
+
+    struct.error: unpack requires a buffer of N bytes
+
+This patch replaces ``_receive`` with a version that loops over
+``socket.recv()`` calls, feeding each chunk through the existing
+(stateful) ``RSCPEncryptDecrypt.decrypt()`` incrementally, until enough
+decrypted bytes are available to satisfy the frame length declared in
+the header. This mirrors the intended usage of ``decrypt()`` -- it
+already tracks IV chaining and left-over partial blocks across calls,
+it was just never invoked more than once by ``_receive``.
+
+A fix has been proposed upstream:
+https://github.com/fsantini/python-e3dc (see PR referenced in the
+hacs-e3dc changelog). This module can be dropped once python-e3dc
+ships the fix and the minimum version is bumped in ``manifest.json``.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import struct
+
+from e3dc import _e3dc_rscp_local
+from e3dc._rscpLib import endianSwapUint16, rscpDecode
+
+_LOGGER = logging.getLogger(__name__)
+
+_PATCHED = False
+
+# Mirrors the header format used by rscpFrameDecode() in _rscpLib.py.
+_HEADER_FMT = "<HHIIIH"
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+_CRC_SIZE = struct.calcsize("<I")
+
+
+def _receive_full_frame(self: _e3dc_rscp_local.E3DC_RSCP_local):
+    """Read and decrypt a complete RSCP frame, looping over ``recv()``.
+
+    Replacement for ``E3DC_RSCP_local._receive`` that keeps reading
+    until the full encrypted frame has arrived, instead of assuming a
+    single ``socket.recv()`` call returns it all.
+
+    ``RSCPEncryptDecrypt.decrypt()`` is stateful across calls, but its
+    default (``previouslyProcessedData=None``) bookkeeping only tracks
+    how much of the *immediately preceding* chunk was consumed. That
+    is not accurate once more than one chunk arrived with a partial
+    (non-block-aligned) leftover, which silently corrupts the result
+    for three or more reads. To stay correct regardless of how many
+    reads are needed, we re-decrypt the whole accumulated ciphertext
+    from scratch on a throwaway copy of the encrypt/decrypt state on
+    every iteration, and only commit the real, persistent
+    ``self.encdec`` state once we know the full frame is available --
+    matching exactly what would happen if it had arrived in one read.
+    """
+    ciphertext = b""
+
+    while True:
+        chunk = self.socket.recv(_e3dc_rscp_local.BUFFER_SIZE)
+        if len(chunk) == 0:
+            raise _e3dc_rscp_local.RSCPKeyError
+        ciphertext += chunk
+
+        probe_encdec = copy.copy(self.encdec)
+        plaintext = probe_encdec.decrypt(ciphertext)
+
+        if len(plaintext) < _HEADER_SIZE:
+            continue
+
+        _, ctrl, _, _, _, length = struct.unpack(_HEADER_FMT, plaintext[:_HEADER_SIZE])
+        ctrl = endianSwapUint16(ctrl)
+        crc_len = _CRC_SIZE if ctrl & 0x10 else 0
+        needed = _HEADER_SIZE + length + crc_len
+
+        if len(plaintext) >= needed:
+            if len(ciphertext) > len(chunk):
+                _LOGGER.debug(
+                    "RSCP frame reassembly: reassembled %d bytes across "
+                    "multiple reads.",
+                    len(ciphertext),
+                )
+            # Advance the real, persistent decrypt state exactly once,
+            # as if the full ciphertext had arrived in a single read.
+            final_plaintext = self.encdec.decrypt(ciphertext)
+            return rscpDecode(final_plaintext)[0]
+
+        _LOGGER.debug(
+            "RSCP frame reassembly: got %d/%d bytes, reading more",
+            len(plaintext),
+            needed,
+        )
+
+
+def patch_rscp_frame_reassembly() -> None:
+    """Patch pye3dc's local RSCP transport to reassemble split frames.
+
+    Idempotent: safe to call multiple times / from multiple config
+    entries.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    _e3dc_rscp_local.E3DC_RSCP_local._receive = _receive_full_frame
+    _PATCHED = True
+    _LOGGER.debug(
+        "Patched E3DC_RSCP_local._receive for multi-read RSCP frame "
+        "reassembly (large EH/DIAG responses)."
+    )

--- a/custom_components/e3dc_rscp/sensor.py
+++ b/custom_components/e3dc_rscp/sensor.py
@@ -1231,8 +1231,10 @@ def _format_error_time(raw: Any) -> str:
     if value > 1e12:
         value /= 1000.0
     try:
-        return datetime.fromtimestamp(value, tz=UTC).astimezone().strftime(
-            "%Y-%m-%d %H:%M"
+        return (
+            datetime.fromtimestamp(value, tz=UTC)
+            .astimezone()
+            .strftime("%Y-%m-%d %H:%M")
         )
     except (OverflowError, OSError, ValueError):
         return str(raw)

--- a/custom_components/e3dc_rscp/sensor.py
+++ b/custom_components/e3dc_rscp/sensor.py
@@ -1,5 +1,6 @@
 """E3DC sensor platform."""
 
+from datetime import UTC, datetime
 import logging
 from dataclasses import dataclass
 from typing import Any, Final
@@ -45,10 +46,20 @@ class E3DCSensorEntityDescription(SensorEntityDescription):
     """Class describing E3DC Sensor entities."""
 
     icons: dict[str, str] = None
+    attributes_key: str | None = None
 
 
 SENSOR_DESCRIPTIONS: Final[tuple[E3DCSensorEntityDescription, ...]] = (
     # DIAGNOSTIC SENSORS
+    E3DCSensorEntityDescription(
+        key="system-saved-errors",
+        translation_key="system-saved-errors",
+        icon="mdi:alert-circle-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+        attributes_key="system-saved-errors-list",
+        entity_registry_enabled_default=False,
+    ),
     E3DCSensorEntityDescription(
         key="system-derate-percent",
         translation_key="system-derate-percent",
@@ -1210,6 +1221,59 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
+def _format_error_time(raw: Any) -> str:
+    """Format EH timestamps (unix ms/s) for display."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return str(raw) if raw is not None else ""
+    # E3DC EH times are typically unix milliseconds.
+    if value > 1e12:
+        value /= 1000.0
+    try:
+        return datetime.fromtimestamp(value, tz=UTC).astimezone().strftime(
+            "%Y-%m-%d %H:%M"
+        )
+    except (OverflowError, OSError, ValueError):
+        return str(raw)
+
+
+def _clean_error_message(msg: str) -> str:
+    """Strip E3DC hex prefixes like ``0x40000000: Netz L3Min``."""
+    if msg.startswith("0x") and ": " in msg:
+        return msg.split(": ", 1)[1]
+    return msg
+
+
+def _saved_error_attributes(items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build user-friendly attributes for the saved-error history sensor."""
+    ordered = sorted(
+        items,
+        key=lambda item: item.get("time") or 0,
+        reverse=True,
+    )
+    lines: list[str] = []
+    messages: list[str] = []
+    for item in ordered:
+        msg = _clean_error_message(str(item.get("msg") or ""))
+        source = item.get("source") or "?"
+        when = _format_error_time(item.get("time"))
+        cleared = " · behoben" if item.get("cleared") else ""
+        lines.append(f"- **{when}** — {msg} ({source}){cleared}")
+        if msg:
+            messages.append(msg)
+
+    latest = ordered[0] if ordered else None
+    return {
+        "items": ordered,
+        "messages": messages,
+        "latest_message": messages[0] if messages else None,
+        "latest_source": latest.get("source") if latest else None,
+        "latest_time": _format_error_time(latest.get("time")) if latest else None,
+        "summary": "\n".join(lines),
+    }
+
+
 class E3DCSensor(CoordinatorEntity, SensorEntity):
     """Custom E3DC Sensor implementation."""
 
@@ -1237,6 +1301,19 @@ class E3DCSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> StateType:
         """Return the reported sensor value."""
         return self.coordinator.data.get(self.entity_description.key)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return optional attributes referenced by ``attributes_key``."""
+        key = self.entity_description.attributes_key
+        if key is None:
+            return None
+        data = self.coordinator.data.get(key)
+        if data is None:
+            return None
+        if key != "system-saved-errors-list":
+            return {"items": data}
+        return _saved_error_attributes(data)
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/e3dc_rscp/strings.json
+++ b/custom_components/e3dc_rscp/strings.json
@@ -217,6 +217,9 @@
       }
     },
     "sensor": {
+      "system-saved-errors": {
+        "name": "Saved error history"
+      },
       "system-derate-percent": {
         "name": "Derate feed above %"
       },

--- a/custom_components/e3dc_rscp/translations/de.json
+++ b/custom_components/e3dc_rscp/translations/de.json
@@ -1,9 +1,0 @@
-{
-    "entity": {
-        "sensor": {
-            "system-saved-errors": {
-                "name": "Fehlerhistorie"
-            }
-        }
-    }
-}

--- a/custom_components/e3dc_rscp/translations/de.json
+++ b/custom_components/e3dc_rscp/translations/de.json
@@ -1,0 +1,9 @@
+{
+    "entity": {
+        "sensor": {
+            "system-saved-errors": {
+                "name": "Fehlerhistorie"
+            }
+        }
+    }
+}

--- a/custom_components/e3dc_rscp/translations/en.json
+++ b/custom_components/e3dc_rscp/translations/en.json
@@ -217,6 +217,9 @@
             }
         },
         "sensor": {
+            "system-saved-errors": {
+                "name": "Saved error history"
+            },
             "system-derate-percent": {
                 "name": "Derate feed above %"
             },


### PR DESCRIPTION
## Summary
- Adds a diagnostic sensor **Saved error history** (`system-saved-errors`) that polls `EH_REQ_GET_SAVED_ERRORS` every 5 minutes (disabled by default).
- Exposes user-friendly attributes (`latest_message`, `latest_time`, `latest_source`, `messages`, `summary`) plus the raw `items` list for automations/templates.
- Documents a Lovelace Markdown / entities card example in the README for visualization without Developer Tools.
- Active DIAG issues are intentionally **not** included: E3DC returns `RSCP_ERR_ACCESS_DENIED` at normal user levels (verified on hardware).

## Test plan
- [ ] Install/reload integration on an E3DC with RSCP access
- [ ] Enable **Saved error history** on the E3DC device
- [ ] Confirm state is an entry count and attributes populate within one poll cycle
- [ ] Add the README Markdown card with your entity id and verify the list renders
- [ ] Confirm diagnostics dump includes `get_saved_errors`